### PR TITLE
Wrap user company and other info texts

### DIFF
--- a/lib/algora_web/components/user_card.ex
+++ b/lib/algora_web/components/user_card.ex
@@ -42,16 +42,16 @@ defmodule AlgoraWeb.Components.UserCard do
 
               <div class="flex flex-wrap items-center justify-center gap-x-3 gap-y-1 pt-1 text-xs text-gray-300 sm:text-sm">
                 <div :if={@twitter_handle} class="flex items-center gap-1">
-                  <.icon name="tabler-brand-twitter" class="h-4 w-4" />
-                  <span class="whitespace-nowrap">{@twitter_handle}</span>
+                  <.icon name="tabler-brand-twitter" class="h-4 w-4 flex-none" />
+                  <span class="whitespace-nowrap text-wrap">{@twitter_handle}</span>
                 </div>
                 <div :if={@location} class="flex items-center gap-1">
-                  <.icon name="tabler-map-pin" class="h-4 w-4" />
-                  <span class="whitespace-nowrap">{@location}</span>
+                  <.icon name="tabler-map-pin" class="h-4 w-4 flex-none" />
+                  <span class="whitespace-nowrap text-wrap">{@location}</span>
                 </div>
                 <div :if={@company} class="flex items-center gap-1">
-                  <.icon name="tabler-building" class="h-4 w-4" />
-                  <span class="whitespace-nowrap">
+                  <.icon name="tabler-building" class="h-4 w-4 flex-none" />
+                  <span class="whitespace-nowrap text-wrap">
                     {@company |> String.trim_leading("@")}
                   </span>
                 </div>

--- a/lib/algora_web/components/user_card.ex
+++ b/lib/algora_web/components/user_card.ex
@@ -43,15 +43,15 @@ defmodule AlgoraWeb.Components.UserCard do
               <div class="flex flex-wrap items-center justify-center gap-x-3 gap-y-1 pt-1 text-xs text-gray-300 sm:text-sm">
                 <div :if={@twitter_handle} class="flex items-center gap-1">
                   <.icon name="tabler-brand-twitter" class="h-4 w-4 flex-none" />
-                  <span class="whitespace-nowrap text-wrap">{@twitter_handle}</span>
+                  <span class="whitespace-nowrap text-wrap line-clamp-2">{@twitter_handle}</span>
                 </div>
                 <div :if={@location} class="flex items-center gap-1">
                   <.icon name="tabler-map-pin" class="h-4 w-4 flex-none" />
-                  <span class="whitespace-nowrap text-wrap">{@location}</span>
+                  <span class="whitespace-nowrap text-wrap line-clamp-2">{@location}</span>
                 </div>
                 <div :if={@company} class="flex items-center gap-1">
                   <.icon name="tabler-building" class="h-4 w-4 flex-none" />
-                  <span class="whitespace-nowrap text-wrap">
+                  <span class="whitespace-nowrap text-wrap line-clamp-2">
                     {@company |> String.trim_leading("@")}
                   </span>
                 </div>


### PR DESCRIPTION
Currently on the community page some long descriptions overflow:

![image](https://github.com/user-attachments/assets/247a616c-5d17-4870-ab37-54f19a1c2455)

The description can wrap and span multiple lines anyways, so the added height of the other cards on the same row shouldn't be that much of a problem. I set the line clamping on these lines to 2 as they should be one liners anyway in most cases.

`flex: none` is added to the icons to not make them shrink and look bad.

![image](https://github.com/user-attachments/assets/4499dc1e-f955-4f55-9c1c-4deba2c83d5f)
