### PR TITLE
fix: prevent glow element from blocking content interaction

### DIFF
--- a/lib/algora_web/live/community_live.ex
+++ b/lib/algora_web/live/community_live.ex
@@ -324,7 +324,7 @@ defmodule AlgoraWeb.CommunityLive do
               </div>
             </div>
             <div class="z-30 relative mx-auto max-w-7xl px-6 lg:px-8">
-              <.glow class="absolute opacity-25 xl:opacity-75 top-[-320px] md:top-[-480px] xl:right-[120px] -z-[10]" />
+              <.glow class="pointer-events-none absolute opacity-25 xl:opacity-75 top-[-320px] md:top-[-480px] xl:right-[120px] -z-[10]" />
 
               <.form
                 for={@repo_form}
@@ -617,7 +617,7 @@ defmodule AlgoraWeb.CommunityLive do
               <div>algora.io/your/repo</div>
             </div>
             <div class="z-30 relative mx-auto max-w-7xl px-6 lg:px-8">
-              <.glow class="absolute opacity-25 xl:opacity-75 top-[-320px] md:top-[-480px] xl:right-[120px] -z-[10]" />
+              <.glow class="pointer-events-none absolute opacity-25 xl:opacity-75 top-[-320px] md:top-[-480px] xl:right-[120px] -z-[10]" />
 
               <.form
                 for={@repo_form}
@@ -1306,7 +1306,7 @@ defmodule AlgoraWeb.CommunityLive do
 
   defp glow(assigns) do
     ~H"""
-    <%!-- "absolute top-[-320px] md:top-[-480px] xl:right-[120px] -z-[10]" --%>
+    <%!-- "pointer-events-none absolute top-[-320px] md:top-[-480px] xl:right-[120px] -z-[10]" --%>
     <div class={@class}>
       <svg
         xmlns="http://www.w3.org/2000/svg"


### PR DESCRIPTION
Fixes an issue where the glow element was blocking user interaction with elements behind it.
This issue particularly affected some items in the bounties list, which were unclickable on smaller screens.

**Blocking element on large screen**
![image](https://github.com/user-attachments/assets/c7607332-7a06-4cf3-97c9-11945560a346)

**Blocking element on small screen**
![image](https://github.com/user-attachments/assets/7a0cf74e-1ac6-409a-8c23-9fbcdb6e7196)
