### PR TITLE
fix: misaligned user dropdown on safari

### DIFF
--- a/lib/algora_web/components/core_components.ex
+++ b/lib/algora_web/components/core_components.ex
@@ -136,7 +136,7 @@ defmodule AlgoraWeb.CoreComponents do
     ~H"""
     <!-- User account dropdown -->
     <div class={classes(["relative w-full text-left", @class])}>
-      <div>
+      <div class="flex">
         <button
           id={@id}
           type="button"


### PR DESCRIPTION
On Safari, the user dropdown is misaligned as per the pictures below. This fixes the alignment without breaking it in other browsers (checked on Chrome).

| - | Before | After |
| - | - | - |
| **Closed** | <img width="462" alt="before-closed" src="https://github.com/user-attachments/assets/543735e8-b6d1-4c88-a94d-a98a6af324fb" /> | <img width="382" alt="after-closed" src="https://github.com/user-attachments/assets/8f9ba2e5-fe5c-41d4-99cf-a299a46e010d" /> |
| **Open** |  <img width="404" alt="before-open" src="https://github.com/user-attachments/assets/790a861d-eedb-441e-81d0-e03fdd5521d2" /> | <img width="386" alt="after-open" src="https://github.com/user-attachments/assets/eccc266b-93d4-4e29-97f0-dcf7988cf18f" /> |
