### PR TITLE
ASDF fixes to make local build work

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,4 @@
 erlang 27.2
 elixir 1.18.1-otp-27
+pnpm 8.15.9
+nodejs 22.16.0

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ OSS communities and closed source teams can **self-host** or join **[Algora.io](
 
 **[Algora.io](https://algora.io)** is a complete solution for sourcing, screening, interviewing & onboarding engineers to your team.
 
-| Hiring proces                | Benefit                                           |
+| Hiring process               | Benefit                                           |
 | ---------------------------- | ------------------------------------------------- |
 | **sourcing**                 | publish jobs to 50K+ developers, access matches   |
 | **screening**                | auto screen job applicants for OSS contributions  |
@@ -142,7 +142,13 @@ OSS communities and closed source teams can **self-host** or join **[Algora.io](
 
 The easiest way to get up and running is to [install](https://docs.docker.com/get-docker/) and use Docker for running Postgres.
 
-Make sure Docker, Elixir, Erlang and Node.js are all installed on your development machine. You can install Elixir and Erlang/OTP by running [`asdf install`](https://github.com/asdf-vm/asdf) from the project root.
+Make sure Docker, Elixir, Erlang and Node.js are all installed on your development machine. You can install Elixir and Erlang/OTP with [ASDF](https://asdf-vm.com/) from the project root as follows:
+1. [Install ASDF](https://asdf-vm.com/guide/getting-started.html)
+2. `asdf plugin add erlang`
+3. `asdf plugin add elixir`
+4. `asdf plugin add pnpm`
+5. `asdf plugin add nodejs`
+6. `asdf install`
 
 We also recommend using [direnv](https://github.com/direnv/direnv) to load environment variables and [entr](https://github.com/eradman/entr) to watch for file changes.
 

--- a/assets/pnpm-lock.yaml
+++ b/assets/pnpm-lock.yaml
@@ -975,8 +975,8 @@ packages:
     resolution: {integrity: sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==}
     dev: true
 
-  /morphdom@2.7.4:
-    resolution: {integrity: sha512-ATTbWMgGa+FaMU3FhnFYB6WgulCqwf6opOll4CBzmVDTLvPMmUPrEv8CudmLPK0MESa64+6B89fWOxP3+YIlxQ==}
+  /morphdom@2.7.5:
+    resolution: {integrity: sha512-z6bfWFMra7kBqDjQGHud1LSXtq5JJC060viEkQFMBX6baIecpkNr2Ywrn2OQfWP3rXiNFQRPoFjD8/TvJcWcDg==}
     dev: false
 
   /ms@2.1.3:
@@ -1447,5 +1447,5 @@ packages:
     resolution: {directory: ../deps/phoenix_live_view, type: directory}
     name: phoenix_live_view
     dependencies:
-      morphdom: 2.7.4
+      morphdom: 2.7.5
     dev: false


### PR DESCRIPTION
ASDF doesn't default install things unless you have explicitly installed the plugins, and a couple of extra things (pnpm, nodejs) are ASDF compatible but weren't setup for it.