### PR TITLE
fix: p tag respects newlines

### DIFF
--- a/lib/algora_web/live/user/profile_live.ex
+++ b/lib/algora_web/live/user/profile_live.ex
@@ -50,7 +50,7 @@ defmodule AlgoraWeb.User.ProfileLive do
               <p class="text-muted-foreground">@{User.handle(@user)}</p>
             </div>
 
-            <p class="max-w-2xl text-foreground">{@user.bio}</p>
+            <p class="max-w-3xl text-foreground whitespace-pre-line">{@user.bio}</p>
 
             <div class="flex flex-wrap gap-4">
               <%= for tech <- @user.tech_stack do %>


### PR DESCRIPTION
Closes #150 
Added class `whitespance-pre-line` https://tailwindcss.com/docs/white-space#pre-line to the p tag containing the bio

Now:
<img width="1248" alt="image" src="https://github.com/user-attachments/assets/29501bc9-8194-43cc-8dce-f928e70b9f71" />


Earlier:
<img width="1168" alt="image" src="https://github.com/user-attachments/assets/d464599e-e4b0-4a50-a9f2-e228535db56c" />
