### PR TITLE
Add rate limiting to send_login_code and send_signup_code endpoints

### DIFF
--- a/lib/algora_web/live/org/dashboard_live.ex
+++ b/lib/algora_web/live/org/dashboard_live.ex
@@ -792,21 +792,29 @@ defmodule AlgoraWeb.Org.DashboardLive do
 
   @impl true
   def handle_event("send_login_code", %{"user" => %{"email" => email}}, socket) do
-    {secret, code} = AlgoraWeb.UserAuth.generate_totp()
+    rate_limit_key = socket.assigns.ip_address
 
-    changeset = User.login_changeset(%User{}, %{})
+    case Algora.RateLimit.hit("send_otp:#{rate_limit_key}", to_timeout(minute: 1), 3) do
+      {:allow, _} ->
+        {secret, code} = AlgoraWeb.UserAuth.generate_totp()
 
-    case Accounts.deliver_totp_signup_email(email, code) do
-      {:ok, _id} ->
-        {:noreply,
-         socket
-         |> assign(:secret, secret)
-         |> assign(:email, email)
-         |> assign_login_form(changeset)}
+        changeset = User.login_changeset(%User{}, %{})
 
-      {:error, reason} ->
-        Logger.error("Failed to send login code to #{email}: #{inspect(reason)}")
-        {:noreply, put_flash(socket, :error, "We had trouble sending mail to #{email}. Please try again")}
+        case Accounts.deliver_totp_signup_email(email, code) do
+          {:ok, _id} ->
+            {:noreply,
+             socket
+             |> assign(:secret, secret)
+             |> assign(:email, email)
+             |> assign_login_form(changeset)}
+
+          {:error, reason} ->
+            Logger.error("Failed to send login code to #{email}: #{inspect(reason)}")
+            {:noreply, put_flash(socket, :error, "We had trouble sending mail to #{email}. Please try again")}
+        end
+
+      {:deny, _} ->
+        {:noreply, put_flash(socket, :error, "Too many requests. Please try again later.")}
     end
   end
 

--- a/lib/algora_web/live/sign_in_live.ex
+++ b/lib/algora_web/live/sign_in_live.ex
@@ -263,21 +263,29 @@ defmodule AlgoraWeb.SignInLive do
 
   @impl true
   def handle_event("send_login_code", %{"user" => %{"email" => email}}, socket) do
-    {secret, code} = AlgoraWeb.UserAuth.generate_totp()
+    rate_limit_key = socket.assigns.ip_address
 
-    changeset = User.login_changeset(%User{}, %{})
+    case Algora.RateLimit.hit("send_otp:#{rate_limit_key}", to_timeout(minute: 1), 3) do
+      {:allow, _} ->
+        {secret, code} = AlgoraWeb.UserAuth.generate_totp()
 
-    case Accounts.deliver_totp_signup_email(email, code) do
-      {:ok, _id} ->
-        {:noreply,
-         socket
-         |> LocalStore.assign_cached(:secret, secret)
-         |> LocalStore.assign_cached(:email, email)
-         |> assign_form(changeset)}
+        changeset = User.login_changeset(%User{}, %{})
 
-      {:error, reason} ->
-        Logger.error("Failed to send login code to #{email}: #{inspect(reason)}")
-        {:noreply, put_flash(socket, :error, "We had trouble sending mail to #{email}. Please try again")}
+        case Accounts.deliver_totp_signup_email(email, code) do
+          {:ok, _id} ->
+            {:noreply,
+             socket
+             |> LocalStore.assign_cached(:secret, secret)
+             |> LocalStore.assign_cached(:email, email)
+             |> assign_form(changeset)}
+
+          {:error, reason} ->
+            Logger.error("Failed to send login code to #{email}: #{inspect(reason)}")
+            {:noreply, put_flash(socket, :error, "We had trouble sending mail to #{email}. Please try again")}
+        end
+
+      {:deny, _} ->
+        {:noreply, put_flash(socket, :error, "Too many requests. Please try again later.")}
     end
   end
 


### PR DESCRIPTION
- Add rate limiting to send_login_code in sign_in_live.ex (3 requests per minute)
- Add rate limiting to send_signup_code in onboarding/dev.ex (3 requests per minute)
- Add rate limiting to send_login_code in org/dashboard_live.ex (3 requests per minute)
- Rate limiting uses IP address as key and follows the same pattern as OTP verification