### PR TITLE
fix(ui): hide bounty management buttons from non-owners (#179)

### DIFF
--- a/lib/algora_web/live/org/bounties_live.ex
+++ b/lib/algora_web/live/org/bounties_live.ex
@@ -215,7 +215,7 @@ defmodule AlgoraWeb.Org.BountiesLive do
                       <% end %>
                     </td>
                     <td class="[&:has([role=checkbox])]:pr-0 p-4 align-middle">
-                      <div class="flex items-center justify-end gap-2">
+                      <div :if={can_manage_bounties?(assigns)} class="flex items-center justify-end gap-2">
                         <.button
                           phx-click="edit-bounty-amount"
                           phx-value-id={bounty.id}
@@ -616,6 +616,20 @@ defmodule AlgoraWeb.Org.BountiesLive do
     Enum.map(bounties, fn bounty ->
       %{bounty: bounty, claim_groups: Map.get(claims_by_ticket, bounty.ticket.id, %{})}
     end)
+  end
+
+  defp can_manage_bounties?(assigns) do
+    user = assigns[:current_user]
+    org = assigns[:current_org]
+
+    if user && org do
+      case Algora.Organizations.fetch_member(org.id, user.id) do
+        {:ok, member} -> member.role in [:admin, :mod]
+        _ -> false
+      end
+    else
+      false
+    end
   end
 
   defp to_transaction_rows(transactions), do: transactions


### PR DESCRIPTION
Ensures that 'Edit Amount' and 'Delete' buttons are only visible to authorized organization members (admin/mod).