### PR TITLE
Docker Build Fix: Add dependencies for Elixir slim image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -84,6 +84,7 @@ COPY --from=node_stage /usr/local/bin /usr/local/bin
 
 RUN apt-get update -y && \
   apt-get install -y libstdc++6 openssl libncurses5 locales ca-certificates fonts-liberation fonts-noto-color-emoji fonts-noto-cjk fonts-dejavu fonts-freefont-ttf libasound2 libatk-bridge2.0-0 libatk1.0-0 libc6 libcairo2 libcups2 libdbus-1-3 libexpat1 libfontconfig1 libgbm1 libgcc1 libglib2.0-0 libgtk-3-0 libnspr4 libnss3 libpango-1.0-0 libpangocairo-1.0-0 libstdc++6 libx11-6 libx11-xcb1 libxcb1 libxcomposite1 libxcursor1 libxdamage1 libxext6 libxfixes3 libxi6 libxrandr2 libxrender1 libxss1 libxtst6 lsb-release wget xdg-utils \
+  zlib1g libgcc-s1 \
   && apt-get clean && rm -f /var/lib/apt/lists/*_*
 
 # Set the locale


### PR DESCRIPTION
Added zlib1g and libgcc-s1 to fix bcrypt compilation on elixir-slim images. Tested on #137.