### PR TITLE
fix(ui): open external bounty links in new tab

### DIFF
--- a/lib/algora_web/components/bounties.ex
+++ b/lib/algora_web/components/bounties.ex
@@ -12,7 +12,7 @@ defmodule AlgoraWeb.Components.Bounties do
     <div class="relative -mx-2 -mt-2 overflow-auto scrollbar-thin">
       <ul class="divide-y divide-border">
         <%= for bounty <- @bounties do %>
-          <.link href={Bounty.url(bounty)} class="block whitespace-nowrap hover:bg-muted/50">
+          <.link href={Bounty.url(bounty)} target="_blank" rel="noopener" class="block whitespace-nowrap hover:bg-muted/50">
             <li class="flex items-center py-2 px-3">
               <div class="flex-shrink-0 mr-3">
                 <.avatar class="h-8 w-8">

--- a/lib/algora_web/live/org/bounties_live.ex
+++ b/lib/algora_web/live/org/bounties_live.ex
@@ -131,6 +131,7 @@ defmodule AlgoraWeb.Org.BountiesLive do
                             </div>
                             <.link
                               rel="noopener"
+                              target="_blank"
                               class="group/issue inline-flex flex-col"
                               href={Bounty.url(bounty)}
                             >

--- a/lib/algora_web/live/org/bounties_new_live.ex
+++ b/lib/algora_web/live/org/bounties_new_live.ex
@@ -158,6 +158,8 @@ defmodule AlgoraWeb.Org.BountiesNewLive do
 
                         <.link
                           href={Bounty.url(bounty)}
+                          target="_blank"
+                          rel="noopener"
                           class="max-w-[400px] truncate text-sm text-foreground hover:underline"
                         >
                           {bounty.ticket.title}
@@ -165,7 +167,7 @@ defmodule AlgoraWeb.Org.BountiesNewLive do
 
                         <div class="flex shrink-0 items-center gap-1 whitespace-nowrap text-sm text-muted-foreground">
                           <.icon name="tabler-chevron-right" class="h-4 w-4" />
-                          <.link href={Bounty.url(bounty)} class="hover:underline">
+                          <.link href={Bounty.url(bounty)} target="_blank" rel="noopener" class="hover:underline">
                             {Bounty.path(bounty)}
                           </.link>
                         </div>

--- a/lib/algora_web/live/org/dashboard_live.ex
+++ b/lib/algora_web/live/org/dashboard_live.ex
@@ -236,6 +236,7 @@ defmodule AlgoraWeb.Org.DashboardLive do
                               </div>
                               <.link
                                 rel="noopener"
+                                target="_blank"
                                 class="group/issue inline-flex flex-col"
                                 href={Bounty.url(bounty)}
                               >

--- a/lib/algora_web/live/org/home_live.ex
+++ b/lib/algora_web/live/org/home_live.ex
@@ -163,6 +163,8 @@ defmodule AlgoraWeb.Org.HomeLive do
 
                           <.link
                             href={Bounty.url(bounty)}
+                            target="_blank"
+                            rel="noopener"
                             class="max-w-[400px] truncate text-sm text-foreground hover:underline"
                           >
                             {bounty.ticket.title}
@@ -173,7 +175,7 @@ defmodule AlgoraWeb.Org.HomeLive do
                             class="flex shrink-0 items-center gap-1 whitespace-nowrap text-sm text-muted-foreground"
                           >
                             <.icon name="tabler-chevron-right" class="h-4 w-4" />
-                            <.link href={Bounty.url(bounty)} class="hover:underline">
+                            <.link href={Bounty.url(bounty)} target="_blank" rel="noopener" class="hover:underline">
                               {Bounty.path(bounty)}
                             </.link>
                           </div>


### PR DESCRIPTION
## Summary
- Adds `target="_blank"` and `rel="noopener"` to all external bounty links (GitHub issue URLs) that were missing it
- Preserves user's Algora browsing context when clicking through to inspect bounty issues on GitHub
- Brings consistency with views that already had this behavior (`bounties_live.ex`, `platform_live.ex`, `primeintellect_live.ex`)

## Files Changed
| File | Change |
|------|--------|
| `components/bounties.ex` | Added `target="_blank" rel="noopener"` to bounty list links |
| `org/bounties_live.ex` | Added `target="_blank"` (already had `rel="noopener"`) |
| `org/bounties_new_live.ex` | Added `target="_blank" rel="noopener"` to title + path links |
| `org/home_live.ex` | Added `target="_blank" rel="noopener"` to title + path links |
| `org/dashboard_live.ex` | Added `target="_blank"` (already had `rel="noopener"`) |

## Test plan
- [ ] Click bounty links on org home page → should open GitHub in new tab
- [ ] Click bounty links on org bounties page → should open GitHub in new tab
- [ ] Click bounty links on org dashboard → should open GitHub in new tab
- [ ] Click bounty links on new bounties page → should open GitHub in new tab
- [ ] Verify Algora page remains open in original tab in all cases

Closes #176