### PR TITLE
fix: update expired Discord invite link

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -14,7 +14,7 @@ config :algora,
   generators: [timestamp_type: :utc_datetime_usec],
   redirects: [
     {"/tv", "https://algora.io"},
-    {"/discord", "https://discord.gg/9RXD2nqbnG"},
+    {"/discord", "https://discord.gg/algora"},
     {"/docs/bounties/payments", "/docs/payments"},
     {"/sdk", "https://github.com/algora-io/sdk"},
     {"/healthcare", "https://blog.algora.io/post/healthcare"},


### PR DESCRIPTION
Closes #161

The Discord invite link in config.exs was expired. Updated to use https://discord.gg/algora which is the current valid invite link for the Algora Discord server.

---

*Contributed by [theluckystrike](https://github.com/theluckystrike) | [Zovo](https://zovo.one) — Chrome Extension Studio*