### PR TITLE
feat: open external bounty links in new tab (fixes #176)

### DIFF
--- a/lib/algora_web/components/bounties.ex
+++ b/lib/algora_web/components/bounties.ex
@@ -12,7 +12,7 @@ defmodule AlgoraWeb.Components.Bounties do
     <div class="relative -mx-2 -mt-2 overflow-auto scrollbar-thin">
       <ul class="divide-y divide-border">
         <%= for bounty <- @bounties do %>
-          <.link href={Bounty.url(bounty)} class="block whitespace-nowrap hover:bg-muted/50">
+          <.link href={Bounty.url(bounty)} target="_blank" class="block whitespace-nowrap hover:bg-muted/50">
             <li class="flex items-center py-2 px-3">
               <div class="flex-shrink-0 mr-3">
                 <.avatar class="h-8 w-8">

--- a/lib/algora_web/live/org/bounties_live.ex
+++ b/lib/algora_web/live/org/bounties_live.ex
@@ -131,6 +131,7 @@ defmodule AlgoraWeb.Org.BountiesLive do
                             </div>
                             <.link
                               rel="noopener"
+                              target="_blank"
                               class="group/issue inline-flex flex-col"
                               href={Bounty.url(bounty)}
                             >

--- a/lib/algora_web/live/org/bounties_new_live.ex
+++ b/lib/algora_web/live/org/bounties_new_live.ex
@@ -158,6 +158,7 @@ defmodule AlgoraWeb.Org.BountiesNewLive do
 
                         <.link
                           href={Bounty.url(bounty)}
+                          target="_blank"
                           class="max-w-[400px] truncate text-sm text-foreground hover:underline"
                         >
                           {bounty.ticket.title}
@@ -165,7 +166,7 @@ defmodule AlgoraWeb.Org.BountiesNewLive do
 
                         <div class="flex shrink-0 items-center gap-1 whitespace-nowrap text-sm text-muted-foreground">
                           <.icon name="tabler-chevron-right" class="h-4 w-4" />
-                          <.link href={Bounty.url(bounty)} class="hover:underline">
+                          <.link href={Bounty.url(bounty)} target="_blank" class="hover:underline">
                             {Bounty.path(bounty)}
                           </.link>
                         </div>

--- a/lib/algora_web/live/org/dashboard_live.ex
+++ b/lib/algora_web/live/org/dashboard_live.ex
@@ -236,6 +236,7 @@ defmodule AlgoraWeb.Org.DashboardLive do
                               </div>
                               <.link
                                 rel="noopener"
+                                target="_blank"
                                 class="group/issue inline-flex flex-col"
                                 href={Bounty.url(bounty)}
                               >

--- a/lib/algora_web/live/org/home_live.ex
+++ b/lib/algora_web/live/org/home_live.ex
@@ -163,6 +163,7 @@ defmodule AlgoraWeb.Org.HomeLive do
 
                           <.link
                             href={Bounty.url(bounty)}
+                            target="_blank"
                             class="max-w-[400px] truncate text-sm text-foreground hover:underline"
                           >
                             {bounty.ticket.title}
@@ -173,7 +174,7 @@ defmodule AlgoraWeb.Org.HomeLive do
                             class="flex shrink-0 items-center gap-1 whitespace-nowrap text-sm text-muted-foreground"
                           >
                             <.icon name="tabler-chevron-right" class="h-4 w-4" />
-                            <.link href={Bounty.url(bounty)} class="hover:underline">
+                            <.link href={Bounty.url(bounty)} target="_blank" class="hover:underline">
                               {Bounty.path(bounty)}
                             </.link>
                           </div>


### PR DESCRIPTION
## Summary
- Added target="_blank" to all Bounty.url links across the codebase
- Improves user experience by preserving navigation context on Algora dashboard
- Users can now "peek" at issues without losing their place

## Files Changed
- lib/algora_web/components/bounties.ex
- lib/algora_web/live/org/home_live.ex
- lib/algora_web/live/org/bounties_live.ex
- lib/algora_web/live/org/dashboard_live.ex
- lib/algora_web/live/org/bounties_new_live.ex

---

*Contributed by [theluckystrike](https://github.com/theluckystrike) | [Zovo](https://zovo.one) — Chrome Extension Studio*