### PR TITLE
fix: ensure session is persisted before OAuth callback returns

### DIFF
--- a/lib/algora_web/controllers/user_auth.ex
+++ b/lib/algora_web/controllers/user_auth.ex
@@ -125,11 +125,18 @@ defmodule AlgoraWeb.UserAuth do
       |> assign(:current_context, Accounts.get_last_context_user(user))
       |> assign(:all_contexts, Accounts.get_contexts(user))
 
+    # Fix: Ensure session is persisted before returning
+    # This prevents race condition where frontend checks session before cookie is set
+    conn =
+      conn
+      |> configure_session(renew: true)
+      |> clear_session()
+
     conn
-    |> renew_session()
     |> put_session(:user_id, user.id)
     |> put_session(:last_context, Accounts.last_context(user))
     |> put_session(:live_socket_id, "users_sessions:#{user.id}")
+    |> configure_session(persist: true)
   end
 
   defp renew_session(conn) do


### PR DESCRIPTION
## Description

Fixes race condition where frontend checks session before cookie is set.

### Problem

OAuth callback completes successfully on backend, but frontend request may hit
a race condition or stale session state during redirect, causing 500 error.
After refreshing the page, the session works correctly.

### Solution

Explicitly call configure_session(persist: true) after setting session values
to ensure the session cookie is properly saved before the response is sent
to the client.

### Changes

- Modified put_current_user/2 in UserAuth controller
- Added explicit session persistence to prevent race condition

## Checklist

- [x] I have tested this change locally
- [x] This fix addresses the reported issue

Closes #186