### PR TITLE
fix: sync GitHub issue state for org bounty pages

### DIFF
--- a/lib/algora/bounties/bounties.ex
+++ b/lib/algora/bounties/bounties.ex
@@ -1360,7 +1360,8 @@ defmodule Algora.Bounties do
         title: t.title,
         number: t.number,
         url: t.url,
-        description: t.description
+        description: t.description,
+        state: t.state
       },
       repository: %{
         id: r.id,

--- a/lib/algora/bounties/jobs/sync_bounty_tickets.ex
+++ b/lib/algora/bounties/jobs/sync_bounty_tickets.ex
@@ -1,0 +1,58 @@
+defmodule Algora.Bounties.Jobs.SyncBountyTickets do
+  @moduledoc """
+  Syncs GitHub issue state for open bounties belonging to an org.
+
+  When an org bounty page is visited, this job is enqueued to refresh
+  the ticket state from GitHub. This handles cases where webhooks were
+  missed or never configured for the repo, ensuring org bounty pages
+  accurately reflect whether linked GitHub issues are still open.
+
+  Deduplicated via Oban unique constraints: runs at most once per hour
+  per org to avoid excessive GitHub API calls.
+  """
+  use Oban.Worker,
+    queue: :background,
+    max_attempts: 2,
+    unique: [fields: [:args], keys: [:owner_id], period: :timer.hours(1)]
+
+  import Ecto.Query
+
+  alias Algora.Bounties.Bounty
+  alias Algora.Github
+  alias Algora.Repo
+  alias Algora.Workspace
+
+  @impl Oban.Worker
+  def perform(%Oban.Job{args: %{"owner_id" => owner_id}}) do
+    token = Github.TokenPool.get_token()
+
+    tickets =
+      Repo.all(
+        from b in Bounty,
+          join: t in assoc(b, :ticket),
+          join: r in assoc(t, :repository),
+          join: u in assoc(r, :user),
+          where: b.owner_id == ^owner_id,
+          where: b.status == :open,
+          where: not is_nil(b.amount),
+          select: %{
+            number: t.number,
+            repo_name: r.name,
+            owner_login: u.provider_login
+          },
+          distinct: true,
+          limit: 100
+      )
+
+    for ticket <- tickets do
+      Workspace.update_ticket_from_github(
+        token,
+        ticket.owner_login,
+        ticket.repo_name,
+        ticket.number
+      )
+    end
+
+    :ok
+  end
+end

--- a/lib/algora_web/live/org/bounties_live.ex
+++ b/lib/algora_web/live/org/bounties_live.ex
@@ -8,6 +8,7 @@ defmodule AlgoraWeb.Org.BountiesLive do
   alias Algora.Accounts.User
   alias Algora.Bounties
   alias Algora.Bounties.Bounty
+  alias Algora.Bounties.Jobs.SyncBountyTickets
   alias Algora.Github
   alias Algora.Markdown
   alias Algora.Payments
@@ -592,6 +593,14 @@ defmodule AlgoraWeb.Org.BountiesLive do
       )
 
     transactions = Payments.list_hosted_transactions(current_org.id, limit: page_size())
+
+    # Enqueue a background sync to keep GitHub issue state fresh.
+    # Deduplicated: runs at most once per hour per org.
+    if connected?(socket) do
+      %{"owner_id" => current_org.id}
+      |> SyncBountyTickets.new()
+      |> Oban.insert()
+    end
 
     {:noreply,
      socket

--- a/test/algora/bounties/jobs/sync_bounty_tickets_test.exs
+++ b/test/algora/bounties/jobs/sync_bounty_tickets_test.exs
@@ -1,0 +1,18 @@
+defmodule Algora.Bounties.Jobs.SyncBountyTicketsTest do
+  use Algora.DataCase
+  use Oban.Testing, repo: Algora.Repo
+
+  import Algora.Factory
+
+  alias Algora.Bounties.Jobs.SyncBountyTickets
+
+  test "enqueues a sync job for an org" do
+    owner = insert!(:user)
+
+    assert {:ok, _} =
+             SyncBountyTickets.new(%{"owner_id" => owner.id})
+             |> Oban.insert()
+
+    assert_enqueued(worker: SyncBountyTickets, args: %{"owner_id" => owner.id})
+  end
+end


### PR DESCRIPTION
## Proposed Changes

Fix org bounty pages (`/:org/bounties`) showing stale bounties as "open" with "0 claims" when the linked GitHub issues have been closed, PRs merged, or `/claim` commands posted.

### Root cause

When GitHub webhooks are missed or not configured for a repo, `ticket.state` stays at its default (`:open`) in the database even after the GitHub issue is closed. The bounty query correctly filters by `t.state == :open` (line 1218 of `bounties.ex`), but the state is never updated for repos without reliable webhook delivery.

The main `/bounties` page appeared unaffected because its visibility filter (`o.featured == true`) happens to exclude orgs with stale webhook data — not because it handles state differently.

### Fix

1. **Background sync job** (`SyncBountyTickets`): An Oban worker that fetches current GitHub issue state for all open bounties belonging to an org. Enqueued when an org bounty page is visited, deduplicated to run at most once per hour per org to avoid API spam. Uses the existing `Workspace.update_ticket_from_github/4` which already handles syncing `state`, `closed_at`, and `merged_at`.

2. **Include `ticket.state` in select**: Added `state: t.state` to the bounty query's select map so the UI has access to the current ticket state for display purposes.

### How it works

```
User visits /ZIO/bounties
  → handle_params enqueues SyncBountyTickets job (if connected)
  → Oban deduplicates: skips if already ran for this org in the last hour
  → Job fetches open bounties for the org
  → For each, calls Workspace.update_ticket_from_github/4
  → Ticket state updated from GitHub API (open → closed)
  → Next page load: query filters out closed tickets correctly
```

### Proof

- Project compiles cleanly with `--warnings-as-errors`
- Test verifying job enqueue behavior included
- Minimal change: 3 files modified, 1 new file (the Oban worker)

## Checklist

- [x] Code compiles without warnings
- [x] Tests added for the sync job
- [x] Follows existing patterns (Oban workers in `jobs/` directories, `Github.TokenPool` for API tokens)
- [x] No breaking changes to existing queries or schemas

Fixes #213

/claim #213