### PR TITLE
fix: filter bounties by ticket state + handle /claim from issue comments

### DIFF
--- a/lib/algora/bounties/bounties.ex
+++ b/lib/algora/bounties/bounties.ex
@@ -1332,6 +1332,7 @@ defmodule Algora.Bounties do
     |> join(:left, [r: r], ro in assoc(r, :user), as: :ro)
     |> where([b], not is_nil(b.amount))
     |> where([b], b.status != :cancelled)
+    |> where([t: t], t.state == :open)
     |> apply_criteria(criteria)
   end
 

--- a/lib/algora_web/controllers/webhooks/github_controller.ex
+++ b/lib/algora_web/controllers/webhooks/github_controller.ex
@@ -536,6 +536,47 @@ defmodule AlgoraWeb.Webhooks.GithubController do
   end
 
   defp execute_command(%Webhook{event_action: event_action, author: author, payload: payload}, {:claim, args})
+       when event_action in ["issue_comment.created", "issue_comment.edited"] do
+    source_ticket_ref = %{
+      owner: payload["repository"]["owner"]["login"],
+      repo: payload["repository"]["name"],
+      number: payload["issue"]["number"]
+    }
+
+    target_ticket_ref =
+      %{
+        owner: args[:ticket_ref][:owner] || source_ticket_ref.owner,
+        repo: args[:ticket_ref][:repo] || source_ticket_ref.repo,
+        number: args[:ticket_ref][:number]
+      }
+
+    with {:ok, token} <- Github.get_installation_token(payload["installation"]["id"]),
+         {:ok, user} <- Workspace.ensure_user(token, author["login"]),
+         {:ok, target_ticket} <-
+           Workspace.ensure_ticket(
+             token,
+             target_ticket_ref.owner,
+             target_ticket_ref.repo,
+             target_ticket_ref.number
+           ),
+         {:ok, claims} <-
+           Bounties.claim_bounty(
+             %{
+               user: user,
+               coauthor_provider_logins: (args[:splits] || []) |> Enum.map(& &1[:recipient]) |> Enum.uniq(),
+               target_ticket_ref: target_ticket_ref,
+               source_ticket_ref: source_ticket_ref,
+               status: :pending,
+               type: :review
+             },
+             installation_id: payload["installation"]["id"]
+           ) do
+      Bounties.try_refresh_bounty_response(token, target_ticket_ref, target_ticket)
+      {:ok, claims}
+    end
+  end
+
+  defp execute_command(%Webhook{event_action: event_action, author: author, payload: payload}, {:claim, args})
        when event_action in ["pull_request.opened", "pull_request.reopened", "pull_request.edited"] do
     source_ticket_ref = %{
       owner: payload["repository"]["owner"]["login"],


### PR DESCRIPTION
## Summary

Fixes #213 - UI Bug: Org bounty pages show stale bounties as open with 0 claims despite GitHub activity

### Bug 1: Stale bounties showing as open (closed GitHub issues)

**Root cause:**  did not filter by ticket state, while  did (). This caused closed GitHub issues to still appear as open bounties on org bounty pages.

**Fix:** Added  to  in , matching the existing behavior in .

### Bug 2: /claim from issue comments not creating claims (0 claims badge)

**Root cause:** The  handler for  only handled PR events (). When users posted  as an issue comment (common workflow), the command was silently ignored.

**Fix:** Added a new  clause to handle  from  events, creating a claim with  and .

### Testing

- Elixir compilation: 
- Run tests:  (recommended: run related bounty and webhook tests)

Closes #213