### PR TITLE
fix: use current_status to filter org bounties instead of hardcoding :open

### DIFF
--- a/lib/algora_web/live/org/bounties_live.ex
+++ b/lib/algora_web/live/org/bounties_live.ex
@@ -587,7 +587,7 @@ defmodule AlgoraWeb.Org.BountiesLive do
       Bounties.list_bounties(
         owner_id: current_org.id,
         limit: page_size(),
-        status: :open,
+        status: current_status,
         current_user: socket.assigns[:current_user]
       )
 
@@ -681,7 +681,7 @@ defmodule AlgoraWeb.Org.BountiesLive do
       Bounties.list_bounties(
         owner_id: current_org.id,
         limit: page_size(),
-        status: :open,
+        status: current_status,
         current_user: socket.assigns[:current_user]
       )
 


### PR DESCRIPTION
Fixes #213

### Root Cause
In `AlgoraWeb.Org.BountiesLive`, the `handle_params` callback was hardcoding the `:open` status when calling `Bounties.list_bounties()`. This meant that even when users clicked the 'Completed' tab, the backend query was filtering out any non-open bounties, causing a mismatch between the tab state, the UI display, and the underlying GitHub issue states.

### Changes
* Replaced `status: :open` with `status: current_status` in `lib/algora_web/live/org/bounties_live.ex` inside `handle_params` and `assign_more_bounties`. This ensures that toggling between tabs fetches the correct slice of data and syncs visually.