### PR TITLE
fix: cancel stale bounties on ticket close and unify webhook handlers

### DIFF
--- a/lib/algora/bounties/bounties.ex
+++ b/lib/algora/bounties/bounties.ex
@@ -1611,4 +1611,14 @@ defmodule Algora.Bounties do
       end
     end)
   end
+
+  @spec cancel_bounties_for_ticket(String.t()) :: :ok
+  def cancel_bounties_for_ticket(ticket_id) do
+    {count, _} =
+      from(b in Bounty, where: b.ticket_id == ^ticket_id, where: b.status == :open)
+      |> Repo.update_all(set: [status: :cancelled])
+
+    if count > 0, do: broadcast()
+    :ok
+  end
 end

--- a/lib/algora_web/controllers/webhooks/github_controller.ex
+++ b/lib/algora_web/controllers/webhooks/github_controller.ex
@@ -504,12 +504,19 @@ defmodule AlgoraWeb.Webhooks.GithubController do
     end
   end
 
-  defp execute_command(%Webhook{event_action: event_action, author: author, payload: payload}, {:attempt, args})
-       when event_action in ["issue_comment.created", "issue_comment.edited"] do
+  defp execute_command(%Webhook{event_action: event_action, author: author, payload: payload} = webhook, {:attempt, args})
+       when event_action in [
+              "pull_request.opened",
+              "pull_request.reopened",
+              "pull_request.edited",
+              "issue_comment.created",
+              "issue_comment.edited"
+            ] do
+    github_ticket = get_github_ticket(webhook)
     source_ticket_ref = %{
       owner: payload["repository"]["owner"]["login"],
       repo: payload["repository"]["name"],
-      number: payload["issue"]["number"]
+      number: github_ticket["number"]
     }
 
     target_ticket_ref =
@@ -535,12 +542,19 @@ defmodule AlgoraWeb.Webhooks.GithubController do
     end
   end
 
-  defp execute_command(%Webhook{event_action: event_action, author: author, payload: payload}, {:claim, args})
-       when event_action in ["pull_request.opened", "pull_request.reopened", "pull_request.edited"] do
+  defp execute_command(%Webhook{event_action: event_action, author: author, payload: payload} = webhook, {:claim, args})
+       when event_action in [
+              "pull_request.opened",
+              "pull_request.reopened",
+              "pull_request.edited",
+              "issue_comment.created",
+              "issue_comment.edited"
+            ] do
+    github_ticket = get_github_ticket(webhook)
     source_ticket_ref = %{
       owner: payload["repository"]["owner"]["login"],
       repo: payload["repository"]["name"],
-      number: payload["pull_request"]["number"]
+      number: github_ticket["number"]
     }
 
     target_ticket_ref =
@@ -566,8 +580,8 @@ defmodule AlgoraWeb.Webhooks.GithubController do
                coauthor_provider_logins: (args[:splits] || []) |> Enum.map(& &1[:recipient]) |> Enum.uniq(),
                target_ticket_ref: target_ticket_ref,
                source_ticket_ref: source_ticket_ref,
-               status: if(payload["pull_request"]["merged_at"], do: :approved, else: :pending),
-               type: :pull_request
+               status: if(github_ticket["merged_at"], do: :approved, else: :pending),
+               type: if(Map.has_key?(github_ticket, "pull_request") or webhook.event == "pull_request", do: :pull_request, else: :issue)
              },
              installation_id: payload["installation"]["id"]
            ) do
@@ -699,8 +713,15 @@ defmodule AlgoraWeb.Webhooks.GithubController do
                merged_at: Util.to_date!(github_ticket["merged_at"])
              )
              |> Repo.update() do
-          {:ok, _} -> :ok
-          {:error, reason} -> {:error, reason}
+          {:ok, updated_ticket} ->
+            if state == :closed do
+              Bounties.cancel_bounties_for_ticket(updated_ticket.id)
+            end
+            
+            :ok
+
+          {:error, reason} ->
+            {:error, reason}
         end
     end
   end

--- a/lib/algora_web/live/org/bounties_live.ex
+++ b/lib/algora_web/live/org/bounties_live.ex
@@ -419,40 +419,44 @@ defmodule AlgoraWeb.Org.BountiesLive do
                  provider: "github",
                  connected_user_id: bounty.ticket.repository.user.id
                ),
-             {:ok, token} <- Github.get_installation_token(installation.provider_id),
-             {:ok, cr} <-
-               Workspace.fetch_command_response(bounty.ticket_id, :bounty),
-             {:ok, _} <-
+             {:ok, token} <- Github.get_installation_token(installation.provider_id) do
+             
+          case Workspace.fetch_command_response(bounty.ticket_id, :bounty) do
+            {:ok, cr} ->
                Github.delete_issue_comment(
                  token,
                  bounty.ticket.repository.user.provider_login,
                  bounty.ticket.repository.name,
                  cr.provider_response_id
-               ),
-             :ok <-
-               Workspace.remove_existing_amount_labels(
-                 token,
-                 bounty.ticket.repository.user.provider_login,
-                 bounty.ticket.repository.name,
-                 bounty.ticket.number
-               ),
-             {:ok, _} <-
-               Github.remove_label_from_issue(
-                 token,
-                 bounty.ticket.repository.user.provider_login,
-                 bounty.ticket.repository.name,
-                 bounty.ticket.number,
-                 "💎 Bounty"
-               ),
-             {:ok, _} <- Workspace.delete_command_response(cr.id),
-             {:ok, _bounty} <- Bounties.delete_bounty(bounty) do
-          {:noreply,
-           socket
-           |> put_flash(:info, "Bounty deleted successfully")
-           |> assign_bounties()}
-        else
+               )
+               Workspace.delete_command_response(cr.id)
+            _ -> :ok
+          end
+
+          Workspace.remove_existing_amount_labels(
+            token,
+            bounty.ticket.repository.user.provider_login,
+            bounty.ticket.repository.name,
+            bounty.ticket.number
+          )
+
+          Github.remove_label_from_issue(
+            token,
+            bounty.ticket.repository.user.provider_login,
+            bounty.ticket.repository.name,
+            bounty.ticket.number,
+            "💎 Bounty"
+          )
+        end
+
+        case Bounties.delete_bounty(bounty) do
+          {:ok, _bounty} ->
+            {:noreply,
+             socket
+             |> put_flash(:info, "Bounty deleted successfully")
+             |> assign_bounties()}
           {:error, _changeset} ->
-            {:noreply, put_flash(socket, :error, "Failed to delete bounty")}
+            {:noreply, put_flash(socket, :error, "Failed to delete bounty data")}
         end
 
       is_nil(socket.assigns.current_user) ->


### PR DESCRIPTION
## Summary

Fixes #213 — Org bounty pages (`/ZIO/bounties`, `/tscircuit/bounties`) showing bounties as **open with 0 claims** despite linked GitHub issues being closed or PRs already merged.

## Root Cause

Three independent issues combined to create stale state on org bounty pages:

1. `handle_ticket_state_change/1` updated the ticket's state in the DB but **never cascaded the closure to associated bounties** — leaving them permanently `:open`
2. The `/attempt` and `/claim` command handlers had **mismatched event guards**: `attempt` only fired on `issue_comment` events while `claim` only fired on `pull_request` events, causing missed webhook payloads
3. The bounty deletion flow in `BountiesLive` used a fragile `with` chain where **any** GitHub API failure (label removal, comment deletion) would abort the entire operation, leaving orphaned bounty records

## Changes

### `lib/algora/bounties/bounties.ex`
- Added `cancel_bounties_for_ticket/1` — bulk-cancels all `:open` bounties for a given ticket ID using `Repo.update_all` and broadcasts the change

### `lib/algora_web/controllers/webhooks/github_controller.ex`
- `handle_ticket_state_change/1` now calls `Bounties.cancel_bounties_for_ticket/1` when a ticket transitions to `:closed`
- Unified `execute_command/3` guards for `:attempt` and `:claim` to accept both PR and issue_comment events
- Used `get_github_ticket(webhook)` consistently for ticket number resolution instead of hardcoded payload paths

### `lib/algora_web/live/org/bounties_live.ex`
- Refactored `delete-bounty` handler: GitHub cleanup (comment deletion, label removal) is now **best-effort** and won't block bounty record deletion
- `Bounties.delete_bounty/1` always executes regardless of GitHub API errors