### PR TITLE
fix: migrate remaining OAuth flows to redirect callback

### DIFF
--- a/lib/algora_web/live/crowdfund.ex
+++ b/lib/algora_web/live/crowdfund.ex
@@ -437,7 +437,7 @@ defmodule AlgoraWeb.CrowdfundLive do
         {:noreply,
          socket
          |> assign(:pending_action, {event, unsigned_params})
-         |> push_event("open_popup", %{url: socket.assigns.oauth_url})}
+         |> redirect(external: socket.assigns.oauth_url)}
       end
     else
       {:noreply, assign(socket, :bounty_form, to_form(changeset))}
@@ -474,7 +474,7 @@ defmodule AlgoraWeb.CrowdfundLive do
         {:noreply,
          socket
          |> assign(:pending_action, {event, unsigned_params})
-         |> push_event("open_popup", %{url: socket.assigns.oauth_url})}
+         |> redirect(external: socket.assigns.oauth_url)}
       end
     else
       {:noreply, assign(socket, :tip_form, to_form(changeset))}

--- a/lib/algora_web/live/org/bounties_new_live.ex
+++ b/lib/algora_web/live/org/bounties_new_live.ex
@@ -323,7 +323,7 @@ defmodule AlgoraWeb.Org.BountiesNewLive do
       {:noreply,
        socket
        |> assign(:pending_action, {event, unsigned_params})
-       |> push_event("open_popup", %{url: socket.assigns.oauth_url})}
+       |> redirect(external: socket.assigns.oauth_url)}
     end
   end
 

--- a/lib/algora_web/live/org/settings_live.ex
+++ b/lib/algora_web/live/org/settings_live.ex
@@ -286,7 +286,7 @@ defmodule AlgoraWeb.Org.SettingsLive do
      else
        socket
        |> assign(:pending_action, {event, unsigned_params})
-       |> push_event("open_popup", %{url: socket.assigns.oauth_url})
+       |> redirect(external: socket.assigns.oauth_url)
      end}
   end
 

--- a/lib/algora_web/live/swift_bounties_live.ex
+++ b/lib/algora_web/live/swift_bounties_live.ex
@@ -584,7 +584,7 @@ defmodule AlgoraWeb.SwiftBountiesLive do
         {:noreply,
          socket
          |> assign(:pending_action, {event, unsigned_params})
-         |> push_event("open_popup", %{url: socket.assigns.oauth_url})}
+         |> redirect(external: socket.assigns.oauth_url)}
       end
     else
       {:noreply, assign(socket, :bounty_form, to_form(changeset))}
@@ -620,7 +620,7 @@ defmodule AlgoraWeb.SwiftBountiesLive do
         {:noreply,
          socket
          |> assign(:pending_action, {event, unsigned_params})
-         |> push_event("open_popup", %{url: socket.assigns.oauth_url})}
+         |> redirect(external: socket.assigns.oauth_url)}
       end
     else
       {:noreply, assign(socket, :tip_form, to_form(changeset))}


### PR DESCRIPTION
## Summary

Completes the migration started in #136 and 735485b. Replaces all remaining `push_event("open_popup", ...)` calls with redirect-based OAuth flows in the 4 remaining files from the checklist.

**Files changed:**
- `lib/algora_web/live/crowdfund.ex`
- `lib/algora_web/live/swift_bounties_live.ex`
- `lib/algora_web/live/org/bounties_new_live.ex`
- `lib/algora_web/live/org/settings_live.ex`

## The Problem

Pop-up windows have inconsistent behavior across devices and browsers (see #135). The maintainer identified this as a reliability issue and began the migration in previous PRs.

## The Pattern Applied

**Before (popup):**
```elixir
|> assign(:pending_action, {event, unsigned_params})
|> push_event("open_popup", %{url: socket.assigns.oauth_url})
```

**After (redirect):**
```elixir
|> assign(:pending_action, {event, unsigned_params})
|> redirect(external: socket.assigns.oauth_url)
```

The `oauth_url` already encodes the `socket_id` in the state parameter (via `Github.authorize_url(%{socket_id: socket.id})`), so the PubSub broadcast in `OAuthCallbackController` correctly targets the originating socket after redirect completes.

## Changes

### `swift_bounties_live.ex` (lines 586-587 and 622-623)

Replaces two `push_event("open_popup", ...)` calls - one in `create_bounty` handler and one in `create_tip` handler.

### `crowdfund.ex`
Replaces `push_event("open_popup", ...)` calls in the crowdfund OAuth trigger path.

### `org/bounties_new_live.ex`
Replaces `push_event("open_popup", ...)` calls in the organization bounty creation OAuth trigger.

### `org/settings_live.ex`
Replaces `push_event("open_popup", ...)` calls in the organization settings OAuth flow.

## Testing

- [ ] Verify GitHub OAuth redirects correctly on mobile Safari
- [ ] Verify GitHub OAuth redirects correctly on Chrome/Firefox
- [ ] Verify `pending_action` is preserved after redirect and re-executed post-auth
- [ ] Confirm no regressions in existing popup-free flows

## Checklist

- [x] Follows the same pattern established in #136 and 735485b
- [x] No new dependencies introduced
- [x] All changed files use existing `socket.assigns.oauth_url` 
- [x] PubSub broadcast in `OAuthCallbackController` remains compatible