### PR TITLE
feat: user handle alias redirects

### DIFF
--- a/lib/algora_web/router.ex
+++ b/lib/algora_web/router.ex
@@ -56,6 +56,10 @@ defmodule AlgoraWeb.Router do
 
   redirect("/comfy-org", "/comfy", :permanent)
   redirect("/comfy-org/*path", "/comfy/*path", :permanent)
+  
+  # User/Org alias redirects (Issue #166)
+  redirect("/sayanget", "/say", :temporary)
+  redirect("/sayanget/*path", "/say/*path", :temporary)
 
   scope "/" do
     forward "/asset", AlgoraWeb.Plugs.RewriteAssetsPlug, upstream: :assets_url


### PR DESCRIPTION
Implements Issue #166. Added redirect logic to `router.ex` to support shorter profile links via aliases. This PR demonstrates the mechanism by aliasing `/sayanget` to `/say`. Future aliases can be added to the compile-time `@redirects` list or handled via a dynamic plug.