### PR TITLE
fix: hide bounty admin actions from unauthorized users

### DIFF
--- a/lib/algora_web/live/org/bounties_live.ex
+++ b/lib/algora_web/live/org/bounties_live.ex
@@ -220,7 +220,10 @@ defmodule AlgoraWeb.Org.BountiesLive do
                       <% end %>
                     </td>
                     <td class="[&:has([role=checkbox])]:pr-0 p-4 align-middle">
-                      <div class="flex items-center justify-end gap-2">
+                      <div
+                        :if={@current_user_role in [:admin, :mod]}
+                        class="flex items-center justify-end gap-2"
+                      >
                         <.button
                           phx-click="edit-bounty-amount"
                           phx-value-id={bounty.id}


### PR DESCRIPTION
## Summary
Fixes #238

## Changes
- Hides the `Edit Amount` and `Delete` bounty actions unless the current user has an admin or mod role.
- Keeps the existing server-side authorization checks intact for defense in depth.

## Testing
- `git diff --check`
- `mix format --check-formatted lib/algora_web/live/org/bounties_live.ex` could not be run because this environment does not have Elixir/Mix installed.
