### PR TITLE
Force external bounty links to open in _blank target to preserve navigation context

### DIFF
--- a/lib/algora_web/components/bounties.ex
+++ b/lib/algora_web/components/bounties.ex
@@ -12,7 +12,7 @@ defmodule AlgoraWeb.Components.Bounties do
     <div class="relative -mx-2 -mt-2 overflow-auto scrollbar-thin">
       <ul class="divide-y divide-border">
         <%= for bounty <- @bounties do %>
-          <.link href={Bounty.url(bounty)} class="block whitespace-nowrap hover:bg-muted/50">
+          <.link href={Bounty.url(bounty)} target="_blank" rel="noopener noreferrer" class="block whitespace-nowrap hover:bg-muted/50">
             <li class="flex items-center py-2 px-3">
               <div class="flex-shrink-0 mr-3">
                 <.avatar class="h-8 w-8">

--- a/lib/algora_web/live/org/bounties_new_live.ex
+++ b/lib/algora_web/live/org/bounties_new_live.ex
@@ -165,7 +165,7 @@ defmodule AlgoraWeb.Org.BountiesNewLive do
 
                         <div class="flex shrink-0 items-center gap-1 whitespace-nowrap text-sm text-muted-foreground">
                           <.icon name="tabler-chevron-right" class="h-4 w-4" />
-                          <.link href={Bounty.url(bounty)} class="hover:underline">
+                          <.link href={Bounty.url(bounty)} target="_blank" rel="noopener noreferrer" class="hover:underline">
                             {Bounty.path(bounty)}
                           </.link>
                         </div>

--- a/lib/algora_web/live/org/home_live.ex
+++ b/lib/algora_web/live/org/home_live.ex
@@ -173,7 +173,7 @@ defmodule AlgoraWeb.Org.HomeLive do
                             class="flex shrink-0 items-center gap-1 whitespace-nowrap text-sm text-muted-foreground"
                           >
                             <.icon name="tabler-chevron-right" class="h-4 w-4" />
-                            <.link href={Bounty.url(bounty)} class="hover:underline">
+                            <.link href={Bounty.url(bounty)} target="_blank" rel="noopener noreferrer" class="hover:underline">
                               {Bounty.path(bounty)}
                             </.link>
                           </div>

--- a/lib/algora_web/live/user/profile_live.ex
+++ b/lib/algora_web/live/user/profile_live.ex
@@ -134,6 +134,8 @@ defmodule AlgoraWeb.User.ProfileLive do
                               <.link
                                 :if={ticket.repository}
                                 href={"https://github.com/#{ticket.repository.user.provider_login}/#{ticket.repository.name}/issues/#{ticket.number}"}
+                                target="_blank"
+                                rel="noopener noreferrer"
                                 class="hover:underline"
                               >
                                 {ticket.repository.name}#{ticket.number}
@@ -141,6 +143,8 @@ defmodule AlgoraWeb.User.ProfileLive do
                               <.link
                                 :if={!ticket.repository && ticket.url}
                                 href={ticket.url}
+                                target="_blank"
+                                rel="noopener noreferrer"
                                 class="hover:underline"
                               >
                                 {Algora.Util.path_from_url(ticket.url)}


### PR DESCRIPTION
Closes #176

## Summary of Changes
Added `target="_blank"` and `rel="noopener noreferrer"` to all external bounty and GitHub issue links across the platform. Users can now click bounty links to peek at issues in a new tab and return to the Algora dashboard exactly where they left off.

## Files Modified
- **lib/algora_web/components/bounties.ex**: Main bounty list component
- **lib/algora_web/live/user/profile_live.ex**: User profile bounty links (2 places)
- **lib/algora_web/live/org/home_live.ex**: Organization dashboard bounty links
- **lib/algora_web/live/org/bounties_new_live.ex**: New bounty creation page

## Testing
- All existing external links on the platform that go to GitHub/bounty pages now open in new tabs
- All changes follow existing patterns (`target="_blank"` is already used extensively in other parts of the codebase)

/claim #176