### PR TITLE
fix: persist outbound opt-out on job postings

### DIFF
--- a/lib/algora/jobs/schemas/job_posting.ex
+++ b/lib/algora/jobs/schemas/job_posting.ex
@@ -98,6 +98,7 @@ defmodule Algora.Jobs.JobPosting do
       :max_equity,
       :require_security_clearance,
       :require_us_citizenship,
+      :outbound,
       :custom_question
     ])
     |> generate_id()


### PR DESCRIPTION
## Summary
- persist the `outbound` flag from job posting form submissions
- ensure jobs marked as inactive campaigns stay opted out of outbound recruiting emails

## Testing
- `mix test test/algora/jobs || mix test`
- `git diff --check`

Resolves #241
