### PR TITLE
fix: hide Edit/Delete buttons from unauthorized users (#238) and respect email opt-out (#241)

### DIFF
--- a/lib/algora/cloud.ex
+++ b/lib/algora/cloud.ex
@@ -1,6 +1,10 @@
 defmodule Algora.Cloud do
   @moduledoc false
 
+  alias Algora.Repo
+  alias Algora.Accounts.User
+  alias Algora.Matches.JobMatch
+
   def top_contributions(github_handles) do
     call(AlgoraCloud, :top_contributions, [github_handles], [])
   end
@@ -46,9 +50,18 @@ defmodule Algora.Cloud do
   end
 
   def notify_match(attrs) do
-    # call(AlgoraCloud.Talent.Jobs.SendJobMatchEmail, :send, [attrs])
-    match = Algora.Repo.get_by(Algora.Matches.JobMatch, user_id: attrs.user_id, job_posting_id: attrs.job_posting_id)
-    call(AlgoraCloud.EmailScheduler, :schedule_email, [:job_drip, match.id], {:ok, :skipped})
+    match = Repo.get_by(JobMatch, user_id: attrs.user_id, job_posting_id: attrs.job_posting_id)
+
+    if match && !user_opted_out?(match.user_id) do
+      call(AlgoraCloud.EmailScheduler, :schedule_email, [:job_drip, match.id], {:ok, :skipped})
+    else
+      {:ok, :skipped}
+    end
+  end
+
+  defp user_opted_out?(user_id) do
+    user = Repo.get(User, user_id)
+    user && user.opt_out_algora
   end
 
   def notify_candidate_like(_attrs) do

--- a/lib/algora_web/live/org/bounties_live.ex
+++ b/lib/algora_web/live/org/bounties_live.ex
@@ -222,6 +222,7 @@ defmodule AlgoraWeb.Org.BountiesLive do
                     <td class="[&:has([role=checkbox])]:pr-0 p-4 align-middle">
                       <div class="flex items-center justify-end gap-2">
                         <.button
+                          :if={@current_user_role in [:admin, :mod]}
                           phx-click="edit-bounty-amount"
                           phx-value-id={bounty.id}
                           variant="secondary"
@@ -230,6 +231,7 @@ defmodule AlgoraWeb.Org.BountiesLive do
                           Edit Amount
                         </.button>
                         <.button
+                          :if={@current_user_role in [:admin, :mod]}
                           phx-click="delete-bounty"
                           phx-value-id={bounty.id}
                           variant="destructive"


### PR DESCRIPTION
This PR fixes two issues:

## Issue #238 - [UI Bug] Unauthorized 'Edit' and 'Delete' buttons visible

**File changed:** `lib/algora_web/live/org/bounties_live.ex`

The "Edit Amount" and "Delete" buttons were rendered for all users on the org bounties listing page. While the backend correctly rejected unauthorized requests (showing "You are not authorized" toast messages), the buttons should not be visible at all to users who cannot use them.

**Fix:** Added `:if={@current_user_role in [:admin, :mod]}` guards to both buttons, matching the authorization check already present in the `edit-bounty-amount` and `delete-bounty` event handlers.

## Issue #241 - Platform emails users who have opted out

**File changed:** `lib/algora/cloud.ex`

The `notify_match/1` function was scheduling job match notification emails (via `AlgoraCloud.EmailScheduler`) without checking if the user had set `opt_out_algora` to `true`. This caused users who explicitly opted out of Algora communications to still receive recruitment emails.

**Fix:** Added a check for the user's `opt_out_algora` flag before scheduling the email. If the user has opted out, the email is skipped with `{:ok, :skipped}`.