### PR TITLE
Add graceful Fly deploy helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,7 +211,7 @@ Then pass the resulting image ref to the deploy helper:
 mix run deploy.exs registry.fly.io/algora:deployment-xxxx
 ```
 
-The helper doubles the `app` process group, updates the new machines to the image, marks old machines unhealthy through `/health`, pauses local Oban queues, waits for the Fly checks to drain traffic, and then stops and destroys the old machines.
+The helper doubles the `app` process group, updates the new machines to the image, waits for each replacement machine to pass Fly health checks, marks old machines unhealthy through `/health`, pauses local Oban queues, waits for the Fly checks to drain traffic, and then stops and destroys the old machines.
 
 ### Setting up external services
 

--- a/README.md
+++ b/README.md
@@ -197,6 +197,22 @@ We also recommend using [direnv](https://github.com/direnv/direnv) to load envir
    make watch
    ```
 
+### Graceful Fly.io Deploys
+
+For Fly.io deployments that should avoid interrupting in-flight requests and workers, build and push the image first:
+
+```sh
+fly deploy --build-only --push
+```
+
+Then pass the resulting image ref to the deploy helper:
+
+```sh
+mix run deploy.exs registry.fly.io/algora:deployment-xxxx
+```
+
+The helper doubles the `app` process group, updates the new machines to the image, marks old machines unhealthy through `/health`, pauses local Oban queues, waits for the Fly checks to drain traffic, and then stops and destroys the old machines.
+
 ### Setting up external services
 
 Some features of Algora rely on external services. If you're not planning on using these features, feel free to skip setting them up.

--- a/config/config.exs
+++ b/config/config.exs
@@ -37,6 +37,7 @@ config :algora, AlgoraWeb.Endpoint,
     formats: [html: AlgoraWeb.ErrorHTML, json: AlgoraWeb.ErrorJSON],
     layout: false
   ],
+  drainer: [shutdown: 30_000, check_interval: 1_000],
   pubsub_server: Algora.PubSub,
   live_view: [signing_salt: "lTPawhId"]
 

--- a/deploy.exs
+++ b/deploy.exs
@@ -1,0 +1,173 @@
+defmodule Algora.GracefulDeploy do
+  @moduledoc false
+
+  @default_app "algora"
+  @default_process_group "app"
+  @default_drain_seconds 30
+  @default_shutdown_timeout 120
+  @fly System.get_env("FLY_BIN", "fly")
+  @prepare_command ~s(/app/bin/algora rpc "Algora.Release.prepare_for_deploy()")
+
+  def main(argv) do
+    {opts, args, invalid} =
+      OptionParser.parse(argv,
+        aliases: [a: :app, g: :process_group],
+        switches: [
+          app: :string,
+          process_group: :string,
+          drain_seconds: :integer,
+          shutdown_timeout: :integer
+        ]
+      )
+
+    if invalid != [] or length(args) != 1 do
+      usage()
+    end
+
+    [new_image_ref] = args
+    app = opts[:app] || System.get_env("FLY_APP_NAME") || @default_app
+    process_group = opts[:process_group] || @default_process_group
+    drain_seconds = opts[:drain_seconds] || @default_drain_seconds
+    shutdown_timeout = opts[:shutdown_timeout] || @default_shutdown_timeout
+
+    old_machines = list_process_machines(app, process_group)
+    old_count = length(old_machines)
+
+    if old_count == 0 do
+      raise "No machines found for #{app}/#{process_group}"
+    end
+
+    log_machines("old machines", old_machines)
+
+    scale_count(app, process_group, old_count * 2)
+
+    new_machines =
+      app
+      |> wait_for_machine_count(process_group, old_count * 2)
+      |> Enum.reject(&known_machine?(&1, old_machines))
+
+    log_machines("new machines", new_machines)
+
+    Enum.each(new_machines, fn machine ->
+      run!(
+        "update #{machine["id"]}",
+        ["machine", "update", machine["id"], "--app", app, "--image", new_image_ref, "--yes"]
+      )
+    end)
+
+    Enum.each(old_machines, fn machine ->
+      IO.puts("Marking #{machine["id"]} unhealthy and pausing local queues")
+      run!("prepare #{machine["id"]}", ["machine", "exec", machine["id"], @prepare_command, "--app", app])
+    end)
+
+    IO.puts("Waiting #{drain_seconds}s for Fly checks to stop routing to old machines")
+    Process.sleep(:timer.seconds(drain_seconds))
+
+    Enum.each(old_machines, fn machine ->
+      IO.puts("Stopping #{machine["id"]} with SIGTERM")
+
+      run!(
+        "stop #{machine["id"]}",
+        [
+          "machine",
+          "stop",
+          machine["id"],
+          "--app",
+          app,
+          "--signal",
+          "SIGTERM",
+          "--timeout",
+          to_string(shutdown_timeout),
+          "--wait-timeout",
+          "#{shutdown_timeout}s"
+        ]
+      )
+
+      run!("destroy #{machine["id"]}", ["machine", "destroy", machine["id"], "--app", app, "--force"])
+    end)
+
+    scale_count(app, process_group, old_count)
+  end
+
+  defp list_process_machines(app, process_group) do
+    {json, 0} = run!("list machines", ["machine", "list", "--app", app, "--json"])
+
+    json
+    |> Jason.decode!()
+    |> Enum.filter(&(process_group(&1) == process_group))
+  end
+
+  defp wait_for_machine_count(app, process_group, count, attempts \\ 12)
+
+  defp wait_for_machine_count(app, process_group, count, 0) do
+    machines = list_process_machines(app, process_group)
+    raise "Expected #{count} #{process_group} machines, found #{length(machines)}"
+  end
+
+  defp wait_for_machine_count(app, process_group, count, attempts) do
+    machines = list_process_machines(app, process_group)
+
+    if length(machines) >= count do
+      machines
+    else
+      Process.sleep(:timer.seconds(5))
+      wait_for_machine_count(app, process_group, count, attempts - 1)
+    end
+  end
+
+  defp scale_count(app, process_group, count) do
+    run!("scale #{process_group}=#{count}", [
+      "scale",
+      "count",
+      "#{process_group}=#{count}",
+      "--app",
+      app,
+      "--yes"
+    ])
+  end
+
+  defp known_machine?(machine, machines) do
+    Enum.any?(machines, &(&1["id"] == machine["id"]))
+  end
+
+  defp process_group(machine) do
+    get_in(machine, ["config", "metadata", "fly_process_group"]) ||
+      get_in(machine, ["config", "env", "FLY_PROCESS_GROUP"]) ||
+      machine["process_group"] ||
+      @default_process_group
+  end
+
+  defp log_machines(label, machines) do
+    IO.puts(label)
+
+    machines
+    |> Enum.map(& &1["id"])
+    |> IO.inspect(limit: :infinity)
+  end
+
+  defp run!(label, args) do
+    IO.puts("$ #{@fly} #{Enum.join(args, " ")}")
+
+    case System.cmd(@fly, args, stderr_to_stdout: true) do
+      {output, 0} -> {output, 0}
+      {output, status} -> raise "#{label} failed with status #{status}\n#{output}"
+    end
+  end
+
+  defp usage do
+    IO.puts("""
+    Usage:
+      mix run deploy.exs registry.fly.io/algora:deployment-xxxx
+
+    Options:
+      --app, -a             Fly app name (defaults to FLY_APP_NAME or algora)
+      --process-group, -g   Fly process group to rotate (defaults to app)
+      --drain-seconds       Seconds to wait after marking old machines unhealthy
+      --shutdown-timeout    Seconds Fly should allow SIGTERM shutdown before SIGKILL
+    """)
+
+    System.halt(1)
+  end
+end
+
+Algora.GracefulDeploy.main(System.argv())

--- a/deploy.exs
+++ b/deploy.exs
@@ -4,6 +4,7 @@ defmodule Algora.GracefulDeploy do
   @default_app "algora"
   @default_process_group "app"
   @default_drain_seconds 30
+  @default_health_timeout 180
   @default_shutdown_timeout 120
   @fly System.get_env("FLY_BIN", "fly")
   @prepare_command ~s(/app/bin/algora rpc "Algora.Release.prepare_for_deploy()")
@@ -16,6 +17,7 @@ defmodule Algora.GracefulDeploy do
           app: :string,
           process_group: :string,
           drain_seconds: :integer,
+          health_timeout: :integer,
           shutdown_timeout: :integer
         ]
       )
@@ -28,6 +30,7 @@ defmodule Algora.GracefulDeploy do
     app = opts[:app] || System.get_env("FLY_APP_NAME") || @default_app
     process_group = opts[:process_group] || @default_process_group
     drain_seconds = opts[:drain_seconds] || @default_drain_seconds
+    health_timeout = opts[:health_timeout] || @default_health_timeout
     shutdown_timeout = opts[:shutdown_timeout] || @default_shutdown_timeout
 
     old_machines = list_process_machines(app, process_group)
@@ -54,6 +57,8 @@ defmodule Algora.GracefulDeploy do
         ["machine", "update", machine["id"], "--app", app, "--image", new_image_ref, "--yes"]
       )
     end)
+
+    wait_for_machines_healthy(app, new_machines, health_timeout)
 
     Enum.each(old_machines, fn machine ->
       IO.puts("Marking #{machine["id"]} unhealthy and pausing local queues")
@@ -115,6 +120,80 @@ defmodule Algora.GracefulDeploy do
     end
   end
 
+  defp wait_for_machines_healthy(app, machines, timeout_seconds) do
+    Enum.each(machines, fn machine ->
+      wait_for_machine_healthy(app, machine["id"], timeout_seconds)
+    end)
+  end
+
+  defp wait_for_machine_healthy(app, machine_id, timeout_seconds) do
+    deadline = System.monotonic_time(:millisecond) + :timer.seconds(timeout_seconds)
+
+    wait_for_machine_healthy_until(app, machine_id, deadline)
+  end
+
+  defp wait_for_machine_healthy_until(app, machine_id, deadline) do
+    status = machine_status(app, machine_id)
+
+    if machine_healthy?(status) do
+      IO.puts("Replacement machine #{machine_id} is healthy")
+    else
+      if System.monotonic_time(:millisecond) >= deadline do
+        raise """
+        Replacement machine #{machine_id} did not become healthy before the timeout.
+        Refusing to drain old machines while the new image is not passing Fly checks.
+        """
+      end
+
+      IO.puts("Waiting for replacement machine #{machine_id} to pass Fly checks")
+      Process.sleep(:timer.seconds(5))
+      wait_for_machine_healthy_until(app, machine_id, deadline)
+    end
+  end
+
+  defp machine_status(app, machine_id) do
+    {json, 0} = run!("status #{machine_id}", ["machine", "status", machine_id, "--app", app, "--json"])
+    Jason.decode!(json)
+  end
+
+  defp machine_healthy?(status) do
+    machine_started?(status) and fly_checks_passing?(status)
+  end
+
+  defp machine_started?(%{"state" => "started"}), do: true
+  defp machine_started?(%{"instance" => %{"state" => "started"}}), do: true
+  defp machine_started?(_status), do: false
+
+  defp fly_checks_passing?(status) do
+    statuses =
+      status
+      |> Map.take(["checks"])
+      |> check_statuses()
+
+    statuses != [] and Enum.all?(statuses, &(&1 in ["passing", "passed"]))
+  end
+
+  defp check_statuses(%{"status" => status} = data) when is_binary(status) do
+    child_statuses =
+      data
+      |> Map.drop(["status"])
+      |> check_statuses()
+
+    [status | child_statuses]
+  end
+
+  defp check_statuses(map) when is_map(map) do
+    map
+    |> Map.values()
+    |> Enum.flat_map(&check_statuses/1)
+  end
+
+  defp check_statuses(list) when is_list(list) do
+    Enum.flat_map(list, &check_statuses/1)
+  end
+
+  defp check_statuses(_value), do: []
+
   defp scale_count(app, process_group, count) do
     run!("scale #{process_group}=#{count}", [
       "scale",
@@ -163,6 +242,7 @@ defmodule Algora.GracefulDeploy do
       --app, -a             Fly app name (defaults to FLY_APP_NAME or algora)
       --process-group, -g   Fly process group to rotate (defaults to app)
       --drain-seconds       Seconds to wait after marking old machines unhealthy
+      --health-timeout      Seconds to wait for replacement machines to pass checks
       --shutdown-timeout    Seconds Fly should allow SIGTERM shutdown before SIGKILL
     """)
 

--- a/fly.toml
+++ b/fly.toml
@@ -6,6 +6,7 @@
 app = 'algora'
 primary_region = 'iad'
 kill_signal = 'SIGTERM'
+kill_timeout = 120
 
 [build]
 

--- a/lib/algora/application.ex
+++ b/lib/algora/application.ex
@@ -38,6 +38,7 @@ defmodule Algora.Application do
         Algora.ScreenshotQueue,
         Algora.RateLimit,
         AlgoraWeb.Data.HomeCache,
+        Algora.DeploymentHealth,
         # Start to serve requests, typically the last entry
         AlgoraWeb.Endpoint,
         Algora.Stargazer,

--- a/lib/algora/deployment_health.ex
+++ b/lib/algora/deployment_health.ex
@@ -1,0 +1,43 @@
+defmodule Algora.DeploymentHealth do
+  @moduledoc """
+  Tracks whether this node should receive new traffic during deployments.
+  """
+
+  use GenServer
+
+  def start_link(_opts) do
+    GenServer.start_link(__MODULE__, true, name: __MODULE__)
+  end
+
+  def healthy? do
+    GenServer.call(__MODULE__, :healthy?)
+  end
+
+  def down do
+    GenServer.cast(__MODULE__, :down)
+  end
+
+  def up do
+    GenServer.cast(__MODULE__, :up)
+  end
+
+  @impl true
+  def init(healthy?) do
+    {:ok, healthy?}
+  end
+
+  @impl true
+  def handle_call(:healthy?, _from, healthy?) do
+    {:reply, healthy?, healthy?}
+  end
+
+  @impl true
+  def handle_cast(:down, _healthy?) do
+    {:noreply, false}
+  end
+
+  @impl true
+  def handle_cast(:up, _healthy?) do
+    {:noreply, true}
+  end
+end

--- a/lib/algora/release.ex
+++ b/lib/algora/release.ex
@@ -18,6 +18,11 @@ defmodule Algora.Release do
     {:ok, _, _} = Ecto.Migrator.with_repo(repo, &Ecto.Migrator.run(&1, :down, to: version))
   end
 
+  def prepare_for_deploy do
+    Algora.DeploymentHealth.down()
+    Oban.pause_all_queues(local_only: true)
+  end
+
   defp repos do
     Application.fetch_env!(@app, :ecto_repos)
   end

--- a/lib/algora_web/controllers/health_controller.ex
+++ b/lib/algora_web/controllers/health_controller.ex
@@ -2,6 +2,10 @@ defmodule AlgoraWeb.HealthController do
   use AlgoraWeb, :controller
 
   def index(conn, _params) do
-    send_resp(conn, 200, "OK")
+    if Algora.DeploymentHealth.healthy?() do
+      send_resp(conn, 200, "OK")
+    else
+      send_resp(conn, 503, "Draining")
+    end
   end
 end

--- a/test/algora_web/controllers/health_controller_test.exs
+++ b/test/algora_web/controllers/health_controller_test.exs
@@ -1,0 +1,25 @@
+defmodule AlgoraWeb.HealthControllerTest do
+  use AlgoraWeb.ConnCase
+
+  setup do
+    Algora.DeploymentHealth.up()
+
+    on_exit(fn ->
+      Algora.DeploymentHealth.up()
+    end)
+  end
+
+  test "returns ok while the node is accepting traffic", %{conn: conn} do
+    conn = get(conn, "/health")
+
+    assert response(conn, 200) == "OK"
+  end
+
+  test "returns unavailable while the node is draining", %{conn: conn} do
+    Algora.DeploymentHealth.down()
+
+    conn = get(conn, "/health")
+
+    assert response(conn, 503) == "Draining"
+  end
+end


### PR DESCRIPTION
/claim #78

Bounty issue: algora-io/tv#78. This targets `algora-io/algora` per the maintainer note that the graceful deploy work is still needed in the new app.

## Summary
- Adds `Algora.DeploymentHealth` and makes `/health` return `503` while a node is draining so Fly routes around old machines.
- Adds `Algora.Release.prepare_for_deploy/0` for release RPCs to mark a node unhealthy and pause local Oban queues.
- Adds `deploy.exs` to warm replacement Fly machines with a supplied image, drain old machines, stop/destroy them, and restore the original process count.
- Extends Fly/Phoenix shutdown windows and documents the deployment flow.

## Verification
- Ran `git diff --cached --check` before commit.
- Added `AlgoraWeb.HealthControllerTest` covering healthy and draining responses.
- Not run locally: `mix test` or a live Fly demo. This Windows environment does not have Elixir/Mix, Docker, flyctl, or Fly app credentials installed.

## Demo plan for a Fly app with access
1. Run `fly deploy --build-only --push` and copy the produced `registry.fly.io/algora:deployment-xxxx` image ref.
2. Run `mix run deploy.exs registry.fly.io/algora:deployment-xxxx`.
3. Confirm replacement machines pass Fly checks before old machines are marked draining.
4. Confirm old machines return `503` from `/health`, pause local Oban queues, receive `SIGTERM`, and are destroyed after shutdown.