### PR TITLE
fix: hide Edit Amount and Delete buttons for unauthorized users

### DIFF
--- a/lib/algora_web/live/org/bounties_live.ex
+++ b/lib/algora_web/live/org/bounties_live.ex
@@ -220,6 +220,7 @@ defmodule AlgoraWeb.Org.BountiesLive do
                       <% end %>
                     </td>
                     <td class="[&:has([role=checkbox])]:pr-0 p-4 align-middle">
+                      <%= if @current_user_role in [:admin, :mod] do %>
                       <div class="flex items-center justify-end gap-2">
                         <.button
                           phx-click="edit-bounty-amount"
@@ -238,6 +239,7 @@ defmodule AlgoraWeb.Org.BountiesLive do
                           Delete
                         </.button>
                       </div>
+                      <% end %>
                     </td>
                   </tr>
                   <%= if MapSet.member?(@expanded_bounties, bounty.id) do %>


### PR DESCRIPTION
## Problem

The "Edit Amount" and "Delete" buttons on the org bounties page are visible to all logged-in users, even though the backend correctly rejects unauthorized actions with a flash message.

## Fix

Wrap the action buttons in a `current_user_role in [:admin, :mod]` check, matching the same authorization logic already used in the event handlers (`handle_event("delete-bounty", ...)` and `handle_event("edit-bounty-amount", ...)`).

Buttons are now only rendered for users with admin or mod roles.

Fixes #238