### PR TITLE
Avoid atom creation for activity table lookup

### DIFF
--- a/lib/algora/activities/activities.ex
+++ b/lib/algora/activities/activities.ex
@@ -56,16 +56,26 @@ defmodule Algora.Activities do
   }
 
   @table_from_schema Map.new(@schema_from_table, &{elem(&1, 1), elem(&1, 0)})
+  @schema_from_table_by_name Map.new(@schema_from_table, fn {table, schema} ->
+                               {Atom.to_string(table), schema}
+                             end)
+  @table_from_schema_by_name Map.new(@table_from_schema, fn {schema, table} ->
+                               {Atom.to_string(schema), table}
+                             end)
   @tables Map.keys(@schema_from_table)
   @user_attributes Map.keys(@table_from_user_relation)
 
-  def schema_from_table(name) when is_binary(name), do: name |> String.to_atom() |> schema_from_table()
+  def schema_from_table(name) when is_binary(name) do
+    Map.fetch!(@schema_from_table_by_name, name)
+  end
 
   def schema_from_table(name) when is_atom(name) do
     Map.fetch!(@schema_from_table, name)
   end
 
-  def table_from_schema(name) when is_binary(name), do: name |> String.to_atom() |> table_from_schema()
+  def table_from_schema(name) when is_binary(name) do
+    Map.fetch!(@table_from_schema_by_name, name)
+  end
 
   def table_from_schema(name) when is_atom(name) do
     Map.fetch!(@table_from_schema, name)

--- a/test/algora/activities_test.exs
+++ b/test/algora/activities_test.exs
@@ -1,0 +1,31 @@
+defmodule Algora.ActivitiesTest do
+  use ExUnit.Case, async: true
+
+  alias Algora.Activities
+  alias Algora.Bounties.Bounty
+
+  describe "schema_from_table/1" do
+    test "does not create atoms for unknown table names" do
+      table = "unknown_#{System.unique_integer([:positive])}_activities"
+
+      refute existing_atom?(table)
+
+      assert_raise KeyError, fn ->
+        Activities.schema_from_table(table)
+      end
+
+      refute existing_atom?(table)
+    end
+
+    test "returns schemas for known table names" do
+      assert Activities.schema_from_table("bounty_activities") == Bounty
+    end
+  end
+
+  defp existing_atom?(value) do
+    String.to_existing_atom(value)
+    true
+  rescue
+    ArgumentError -> false
+  end
+end


### PR DESCRIPTION
Summary
- Avoid converting activity table names from strings with `String.to_atom/1`
- Use precomputed string-keyed allowlist maps for binary lookups
- Add regression coverage for unknown activity table names

Security
`/a/:table_prefix/:activity_id` accepts a public path segment. Previously, unknown table names were converted with `String.to_atom/1` before the allowlist lookup failed, which could allow unbounded BEAM atom creation from unauthenticated requests.

Testing
- Focused Docker ExUnit harness: 2 tests, 0 failures