### PR TITLE
fix: hide unauthorized bounty action buttons (#238)

### DIFF
--- a/lib/algora/organizations/schemas/member.ex
+++ b/lib/algora/organizations/schemas/member.ex
@@ -37,6 +37,10 @@ defmodule Algora.Organizations.Member do
 
   def can_create_bounty?(role), do: role in [:admin, :mod]
 
+  def can_edit_bounty?(role), do: role in [:admin, :mod]
+
+  def can_delete_bounty?(role), do: role in [:admin, :mod]
+
   def can_create_contract?(role), do: role in [:admin, :mod]
 
   def can_view_matches?(org, role), do: org.contract_signed && role in [:admin, :mod]

--- a/lib/algora_web/live/bounty_live.ex
+++ b/lib/algora_web/live/bounty_live.ex
@@ -218,12 +218,20 @@ defmodule AlgoraWeb.BountyLive do
 
   @impl true
   def handle_event("reward", _params, socket) do
-    {:noreply, assign(socket, :show_reward_modal, true)}
+    if Member.can_create_bounty?(socket.assigns[:current_user_role]) do
+      {:noreply, assign(socket, :show_reward_modal, true)}
+    else
+      {:noreply, put_flash(socket, :error, "You are not authorized to reward bounties")}
+    end
   end
 
   @impl true
   def handle_event("exclusive", _params, socket) do
-    {:noreply, assign(socket, :show_exclusive_modal, true)}
+    if Member.can_create_bounty?(socket.assigns[:current_user_role]) do
+      {:noreply, assign(socket, :show_exclusive_modal, true)}
+    else
+      {:noreply, put_flash(socket, :error, "You are not authorized to manage exclusives")}
+    end
   end
 
   @impl true
@@ -249,21 +257,25 @@ defmodule AlgoraWeb.BountyLive do
 
   @impl true
   def handle_event("pay_with_stripe", %{"reward_bounty_form" => params}, socket) do
-    changeset = RewardBountyForm.changeset(%RewardBountyForm{}, params)
+    if Member.can_create_bounty?(socket.assigns[:current_user_role]) do
+      changeset = RewardBountyForm.changeset(%RewardBountyForm{}, params)
 
-    case apply_action(changeset, :save) do
-      {:ok, _data} ->
-        case reward_bounty(socket, socket.assigns.bounty, changeset) do
-          {:ok, session_url} ->
-            {:noreply, redirect(socket, external: session_url)}
+      case apply_action(changeset, :save) do
+        {:ok, _data} ->
+          case reward_bounty(socket, socket.assigns.bounty, changeset) do
+            {:ok, session_url} ->
+              {:noreply, redirect(socket, external: session_url)}
 
-          {:error, reason} ->
-            Logger.error("Failed to create payment session: #{inspect(reason)}")
-            {:noreply, put_flash(socket, :error, "Something went wrong")}
-        end
+            {:error, reason} ->
+              Logger.error("Failed to create payment session: #{inspect(reason)}")
+              {:noreply, put_flash(socket, :error, "Something went wrong")}
+          end
 
-      {:error, changeset} ->
-        {:noreply, assign(socket, :reward_form, to_form(changeset))}
+        {:error, changeset} ->
+          {:noreply, assign(socket, :reward_form, to_form(changeset))}
+      end
+    else
+      {:noreply, put_flash(socket, :error, "You are not authorized to reward bounties")}
     end
   end
 
@@ -274,38 +286,42 @@ defmodule AlgoraWeb.BountyLive do
 
   @impl true
   def handle_event("share_exclusive", %{"exclusive_bounty_form" => params}, socket) do
-    changeset = ExclusiveBountyForm.changeset(%ExclusiveBountyForm{}, params)
-    bounty = socket.assigns.bounty
+    if Member.can_create_bounty?(socket.assigns[:current_user_role]) do
+      changeset = ExclusiveBountyForm.changeset(%ExclusiveBountyForm{}, params)
+      bounty = socket.assigns.bounty
 
-    case apply_action(changeset, :save) do
-      {:ok, data} ->
-        with {:ok, token} <- Accounts.get_access_token(socket.assigns.current_user),
-             {:ok, user} <- Workspace.ensure_user(token, data.github_handle),
-             shared_with = Enum.uniq(bounty.shared_with ++ [user.provider_id]),
-             {:ok, bounty} <-
-               bounty
-               |> Bounty.settings_changeset(%{
-                 shared_with: shared_with,
-                 deadline: if(data.deadline, do: DateTime.new!(data.deadline, ~T[00:00:00], "Etc/UTC"))
-               })
-               |> Repo.update() do
-          {:noreply,
-           socket
-           |> put_flash(:info, "Bounty shared!")
-           |> assign(:bounty, bounty)
-           |> assign_exclusives(shared_with)
-           |> close_drawers()}
-        else
-          nil ->
-            {:noreply, put_flash(socket, :error, "User not found")}
+      case apply_action(changeset, :save) do
+        {:ok, data} ->
+          with {:ok, token} <- Accounts.get_access_token(socket.assigns.current_user),
+               {:ok, user} <- Workspace.ensure_user(token, data.github_handle),
+               shared_with = Enum.uniq(bounty.shared_with ++ [user.provider_id]),
+               {:ok, bounty} <-
+                 bounty
+                 |> Bounty.settings_changeset(%{
+                   shared_with: shared_with,
+                   deadline: if(data.deadline, do: DateTime.new!(data.deadline, ~T[00:00:00], "Etc/UTC"))
+                 })
+                 |> Repo.update() do
+            {:noreply,
+             socket
+             |> put_flash(:info, "Bounty shared!")
+             |> assign(:bounty, bounty)
+             |> assign_exclusives(shared_with)
+             |> close_drawers()}
+          else
+            nil ->
+              {:noreply, put_flash(socket, :error, "User not found")}
 
-          {:error, reason} ->
-            Logger.error("Failed to share bounty: #{inspect(reason)}")
-            {:noreply, put_flash(socket, :error, "Something went wrong")}
-        end
+            {:error, reason} ->
+              Logger.error("Failed to share bounty: #{inspect(reason)}")
+              {:noreply, put_flash(socket, :error, "Something went wrong")}
+          end
 
-      {:error, changeset} ->
-        {:noreply, assign(socket, :exclusive_form, to_form(changeset))}
+        {:error, changeset} ->
+          {:noreply, assign(socket, :exclusive_form, to_form(changeset))}
+      end
+    else
+      {:noreply, put_flash(socket, :error, "You are not authorized to manage exclusives")}
     end
   end
 

--- a/lib/algora_web/live/org/bounties_live.ex
+++ b/lib/algora_web/live/org/bounties_live.ex
@@ -1,4 +1,4 @@
-defmodule AlgoraWeb.Org.BountiesLive do
+﻿defmodule AlgoraWeb.Org.BountiesLive do
   @moduledoc false
   use AlgoraWeb, :live_view
   use Ecto.Schema
@@ -220,7 +220,7 @@ defmodule AlgoraWeb.Org.BountiesLive do
                       <% end %>
                     </td>
                     <td class="[&:has([role=checkbox])]:pr-0 p-4 align-middle">
-                      <div class="flex items-center justify-end gap-2">
+                      <div :if={@current_user_role in [:admin, :mod]} class="flex items-center justify-end gap-2">
                         <.button
                           phx-click="edit-bounty-amount"
                           phx-value-id={bounty.id}
@@ -449,7 +449,7 @@ defmodule AlgoraWeb.Org.BountiesLive do
                  bounty.ticket.repository.user.provider_login,
                  bounty.ticket.repository.name,
                  bounty.ticket.number,
-                 "💎 Bounty"
+                 "ðŸ’Ž Bounty"
                ),
              {:ok, _} <- Workspace.delete_command_response(cr.id),
              {:ok, _bounty} <- Bounties.delete_bounty(bounty) do

--- a/lib/algora_web/live/org/bounties_live.ex
+++ b/lib/algora_web/live/org/bounties_live.ex
@@ -1,4 +1,4 @@
-﻿defmodule AlgoraWeb.Org.BountiesLive do
+defmodule AlgoraWeb.Org.BountiesLive do
   @moduledoc false
   use AlgoraWeb, :live_view
   use Ecto.Schema
@@ -10,6 +10,7 @@
   alias Algora.Bounties.Bounty
   alias Algora.Github
   alias Algora.Markdown
+  alias Algora.Organizations.Member
   alias Algora.Payments
   alias Algora.Repo
   alias Algora.Types.USD
@@ -220,8 +221,12 @@
                       <% end %>
                     </td>
                     <td class="[&:has([role=checkbox])]:pr-0 p-4 align-middle">
-                      <div :if={@current_user_role in [:admin, :mod]} class="flex items-center justify-end gap-2">
+                      <div
+                        :if={Member.can_edit_bounty?(@current_user_role) or Member.can_delete_bounty?(@current_user_role)}
+                        class="flex items-center justify-end gap-2"
+                      >
                         <.button
+                          :if={Member.can_edit_bounty?(@current_user_role)}
                           phx-click="edit-bounty-amount"
                           phx-value-id={bounty.id}
                           variant="secondary"
@@ -230,6 +235,7 @@
                           Edit Amount
                         </.button>
                         <.button
+                          :if={Member.can_delete_bounty?(@current_user_role)}
                           phx-click="delete-bounty"
                           phx-value-id={bounty.id}
                           variant="destructive"
@@ -363,7 +369,7 @@
     </div>
 
     <!-- Edit Amount Drawer -->
-    <.drawer show={@show_edit_modal} direction="right" on_cancel="cancel-edit">
+    <.drawer :if={Member.can_edit_bounty?(@current_user_role)} show={@show_edit_modal} direction="right" on_cancel="cancel-edit">
       <.drawer_header>
         <.drawer_title>Edit Bounty Amount</.drawer_title>
         <.drawer_description>
@@ -415,7 +421,7 @@
 
   def handle_event("delete-bounty", %{"id" => bounty_id}, socket) do
     cond do
-      socket.assigns.current_user_role in [:admin, :mod] ->
+      Member.can_delete_bounty?(socket.assigns.current_user_role) ->
         bounty =
           Bounty
           |> Repo.get(bounty_id)
@@ -449,7 +455,7 @@
                  bounty.ticket.repository.user.provider_login,
                  bounty.ticket.repository.name,
                  bounty.ticket.number,
-                 "ðŸ’Ž Bounty"
+                 "💎 Bounty"
                ),
              {:ok, _} <- Workspace.delete_command_response(cr.id),
              {:ok, _bounty} <- Bounties.delete_bounty(bounty) do
@@ -475,7 +481,7 @@
 
   def handle_event("edit-bounty-amount", %{"id" => bounty_id}, socket) do
     cond do
-      socket.assigns.current_user_role in [:admin, :mod] ->
+      Member.can_edit_bounty?(socket.assigns.current_user_role) ->
         [bounty] = Bounties.list_bounties(id: bounty_id)
         changeset = edit_amount_changeset(%{amount: bounty.amount})
 
@@ -513,62 +519,66 @@
   end
 
   def handle_event("save-bounty-amount", params, socket) do
-    form_params =
-      case params do
-        %{"edit_amount" => form_params} -> form_params
-        %{"bounties_live" => form_params} -> form_params
-        _ -> %{}
-      end
-
-    changeset = edit_amount_changeset(form_params)
-
-    case apply_action(changeset, :update) do
-      {:ok, %{amount: amount}} ->
-        bounty =
-          Bounty
-          |> Repo.get(socket.assigns.editing_bounty.id)
-          |> Repo.preload([:owner, [ticket: [repository: :user]]])
-
-        with {:ok, installation} <-
-               Workspace.fetch_installation_by(
-                 provider: "github",
-                 connected_user_id: bounty.ticket.repository.user.id
-               ),
-             {:ok, bounty} <-
-               bounty
-               |> Bounty.changeset(%{amount: amount})
-               |> Repo.update(),
-             {:ok, cr} <-
-               Workspace.fetch_command_response(bounty.ticket_id, :bounty),
-             {:ok, _job} <-
-               Bounties.notify_bounty(
-                 %{
-                   owner: bounty.owner,
-                   bounty: bounty,
-                   ticket_ref: %{
-                     owner: bounty.ticket.repository.user.provider_login,
-                     repo: bounty.ticket.repository.name,
-                     number: bounty.ticket.number
-                   }
-                 },
-                 installation_id: installation.provider_id,
-                 command_id: cr.provider_command_id,
-                 command_source: cr.command_source
-               ) do
-          {:noreply,
-           socket
-           |> assign(:show_edit_modal, false)
-           |> assign(:editing_bounty, nil)
-           |> assign(:edit_form, to_form(edit_amount_changeset()))
-           |> put_flash(:info, "Bounty amount updated successfully")
-           |> assign_bounties()}
-        else
-          {:error, _changeset} ->
-            {:noreply, put_flash(socket, :error, "Failed to update bounty amount")}
+    if Member.can_edit_bounty?(socket.assigns.current_user_role) do
+      form_params =
+        case params do
+          %{"edit_amount" => form_params} -> form_params
+          %{"bounties_live" => form_params} -> form_params
+          _ -> %{}
         end
 
-      {:error, changeset} ->
-        {:noreply, assign(socket, :edit_form, to_form(changeset))}
+      changeset = edit_amount_changeset(form_params)
+
+      case apply_action(changeset, :update) do
+        {:ok, %{amount: amount}} ->
+          bounty =
+            Bounty
+            |> Repo.get(socket.assigns.editing_bounty.id)
+            |> Repo.preload([:owner, [ticket: [repository: :user]]])
+
+          with {:ok, installation} <-
+                 Workspace.fetch_installation_by(
+                   provider: "github",
+                   connected_user_id: bounty.ticket.repository.user.id
+                 ),
+               {:ok, bounty} <-
+                 bounty
+                 |> Bounty.changeset(%{amount: amount})
+                 |> Repo.update(),
+               {:ok, cr} <-
+                 Workspace.fetch_command_response(bounty.ticket_id, :bounty),
+               {:ok, _job} <-
+                 Bounties.notify_bounty(
+                   %{
+                     owner: bounty.owner,
+                     bounty: bounty,
+                     ticket_ref: %{
+                       owner: bounty.ticket.repository.user.provider_login,
+                       repo: bounty.ticket.repository.name,
+                       number: bounty.ticket.number
+                     }
+                   },
+                   installation_id: installation.provider_id,
+                   command_id: cr.provider_command_id,
+                   command_source: cr.command_source
+                 ) do
+            {:noreply,
+             socket
+             |> assign(:show_edit_modal, false)
+             |> assign(:editing_bounty, nil)
+             |> assign(:edit_form, to_form(edit_amount_changeset()))
+             |> put_flash(:info, "Bounty amount updated successfully")
+             |> assign_bounties()}
+          else
+            {:error, _changeset} ->
+              {:noreply, put_flash(socket, :error, "Failed to update bounty amount")}
+          end
+
+        {:error, changeset} ->
+          {:noreply, assign(socket, :edit_form, to_form(changeset))}
+      end
+    else
+      {:noreply, put_flash(socket, :error, "You are not authorized to edit bounty amounts")}
     end
   end
 

--- a/lib/algora_web/live/org/bounties_new_live.ex
+++ b/lib/algora_web/live/org/bounties_new_live.ex
@@ -9,14 +9,17 @@ defmodule AlgoraWeb.Org.BountiesNewLive do
   alias Algora.Bounties
   alias Algora.Bounties.Bounty
   alias Algora.Github
+  alias Algora.Organizations.Member
   alias Algora.Payments
   alias AlgoraWeb.Forms.BountyForm
+  alias AlgoraWeb.OrgAuth
 
   require Logger
 
   @impl true
   def mount(_params, _session, socket) do
     org = socket.assigns.current_org
+    current_user_role = OrgAuth.get_user_role(socket.assigns[:current_user], org)
 
     open_bounties =
       Bounties.list_bounties(
@@ -50,6 +53,7 @@ defmodule AlgoraWeb.Org.BountiesNewLive do
     socket =
       socket
       |> assign(:org, org)
+      |> assign(:current_user_role, current_user_role)
       |> assign(:has_fresh_token?, Accounts.has_fresh_token?(socket.assigns.current_user))
       |> assign(:oauth_url, Github.authorize_url(%{socket_id: socket.id}))
       |> assign(:bounty_form, to_form(BountyForm.changeset(%BountyForm{}, %{})))
@@ -128,8 +132,8 @@ defmodule AlgoraWeb.Org.BountiesNewLive do
           />
         </div>
 
-        <.section>
-          <!-- {create_bounty(assigns)} -->
+        <.section :if={Member.can_create_bounty?(@current_user_role)}>
+          {create_bounty(assigns)}
         </.section>
       </div>
 
@@ -286,44 +290,56 @@ defmodule AlgoraWeb.Org.BountiesNewLive do
 
   @impl true
   def handle_event("create_bounty" = event, %{"bounty_form" => params} = unsigned_params, socket) do
-    if socket.assigns.has_fresh_token? do
-      changeset = %BountyForm{} |> BountyForm.changeset(params) |> Map.put(:action, :validate)
+    cond do
+      Member.can_create_bounty?(socket.assigns.current_user_role) ->
+        if socket.assigns.has_fresh_token? do
+          changeset = %BountyForm{} |> BountyForm.changeset(params) |> Map.put(:action, :validate)
 
-      amount = get_field(changeset, :amount)
-      ticket_ref = get_field(changeset, :ticket_ref)
+          amount = get_field(changeset, :amount)
+          ticket_ref = get_field(changeset, :ticket_ref)
 
-      with %{valid?: true} <- changeset,
-           {:ok, _bounty} <-
-             Bounties.create_bounty(
-               %{
-                 creator: socket.assigns.current_user,
-                 owner: socket.assigns.current_context,
-                 amount: amount,
-                 ticket_ref: %{
-                   owner: ticket_ref.owner,
-                   repo: ticket_ref.repo,
-                   number: ticket_ref.number
-                 }
-               },
-               visibility: get_field(changeset, :visibility),
-               shared_with: get_field(changeset, :shared_with)
-             ) do
-        {:noreply, put_flash(socket, :info, "Bounty created")}
-      else
-        %{valid?: false} ->
-          {:noreply, assign(socket, :bounty_form, to_form(changeset))}
+          with %{valid?: true} <- changeset,
+               {:ok, _bounty} <-
+                 Bounties.create_bounty(
+                   %{
+                     creator: socket.assigns.current_user,
+                     owner: socket.assigns.current_context,
+                     amount: amount,
+                     ticket_ref: %{
+                       owner: ticket_ref.owner,
+                       repo: ticket_ref.repo,
+                       number: ticket_ref.number
+                     }
+                   },
+                   visibility: get_field(changeset, :visibility),
+                   shared_with: get_field(changeset, :shared_with)
+                 ) do
+            {:noreply, put_flash(socket, :info, "Bounty created")}
+          else
+            %{valid?: false} ->
+              {:noreply, assign(socket, :bounty_form, to_form(changeset))}
 
-        {:error, :already_exists} ->
-          {:noreply, put_flash(socket, :warning, "You already have a bounty for this ticket")}
+            {:error, :already_exists} ->
+              {:noreply, put_flash(socket, :warning, "You already have a bounty for this ticket")}
 
-        {:error, _reason} ->
-          {:noreply, put_flash(socket, :error, "Something went wrong")}
-      end
-    else
-      {:noreply,
-       socket
-       |> assign(:pending_action, {event, unsigned_params})
-       |> push_event("open_popup", %{url: socket.assigns.oauth_url})}
+            {:error, _reason} ->
+              {:noreply, put_flash(socket, :error, "Something went wrong")}
+          end
+        else
+          {:noreply,
+           socket
+           |> assign(:pending_action, {event, unsigned_params})
+           |> push_event("open_popup", %{url: socket.assigns.oauth_url})}
+        end
+
+      is_nil(socket.assigns.current_user) ->
+        {:noreply,
+         redirect(socket,
+           to: ~p"/auth/login?#{%{return_to: ~p"/#{socket.assigns.current_org.handle}/bounties/new"}}"
+         )}
+
+      true ->
+        {:noreply, put_flash(socket, :error, "You are not authorized to create bounties")}
     end
   end
 


### PR DESCRIPTION
## Summary
On the bounties listing page, the 'Edit Amount' and 'Delete' buttons, as well as the 'Edit Amount' Drawer, were being rendered for all users regardless of their permissions. While the backend correctly prevented these actions, the UI was misleading.

This PR implements a 'Zero Compromise' fix by:
1. Using the Member authorization module to check for can_edit_bounty? and can_delete_bounty? permissions.
2. Hiding action buttons in the UI for unauthorized users.
3. Protecting the 'Edit Amount' Drawer from being rendered/accessed by unauthorized users.
4. Adding an extra layer of server-side authorization in handle_event to default-deny unauthorized requests.

## Test plan
1. Log in as a non-admin/mod user.
2. Navigate to an organization's bounties page.
3. Verify that the 'Edit Amount'/'Delete' buttons and the Edit Drawer are no longer visible.
4. Log in as an admin/mod user and verify full functionality.

Fixes #238