### PR TITLE
Hide bounty management actions from non-managers

### DIFF
--- a/lib/algora_web/live/org/bounties_live.ex
+++ b/lib/algora_web/live/org/bounties_live.ex
@@ -10,6 +10,7 @@ defmodule AlgoraWeb.Org.BountiesLive do
   alias Algora.Bounties.Bounty
   alias Algora.Github
   alias Algora.Markdown
+  alias Algora.Organizations.Member
   alias Algora.Payments
   alias Algora.Repo
   alias Algora.Types.USD
@@ -220,7 +221,7 @@ defmodule AlgoraWeb.Org.BountiesLive do
                       <% end %>
                     </td>
                     <td class="[&:has([role=checkbox])]:pr-0 p-4 align-middle">
-                      <div class="flex items-center justify-end gap-2">
+                      <div :if={can_manage_bounties?(@current_user_role)} class="flex items-center justify-end gap-2">
                         <.button
                           phx-click="edit-bounty-amount"
                           phx-value-id={bounty.id}
@@ -638,6 +639,8 @@ defmodule AlgoraWeb.Org.BountiesLive do
   end
 
   defp to_transaction_rows(transactions), do: transactions
+
+  defp can_manage_bounties?(role), do: Member.can_create_bounty?(role)
 
   defp assign_more_bounties(socket) do
     %{bounty_rows: rows, current_org: current_org} = socket.assigns

--- a/test/algora_web/live/org/bounties_live_test.exs
+++ b/test/algora_web/live/org/bounties_live_test.exs
@@ -1,0 +1,48 @@
+defmodule AlgoraWeb.Org.BountiesLiveTest do
+  use AlgoraWeb.ConnCase, async: true
+
+  import Algora.Factory
+  import Phoenix.LiveViewTest
+
+  alias AlgoraWeb.UserAuth
+
+  describe "open bounty actions" do
+    test "hides edit and delete actions from non-managers", %{conn: conn} do
+      org = insert!(:organization)
+      user = insert!(:user)
+      repo = insert!(:repository, user: org)
+      ticket = insert!(:ticket, repository: repo)
+      insert!(:bounty, owner: org, ticket: ticket)
+      insert!(:member, user: user, org: org, role: :expert)
+
+      conn =
+        conn
+        |> Phoenix.ConnTest.init_test_session(%{})
+        |> UserAuth.put_current_user(user)
+
+      {:ok, _view, html} = live(conn, ~p"/#{org.handle}/bounties")
+
+      refute html =~ "edit-bounty-amount"
+      refute html =~ "delete-bounty"
+    end
+
+    test "shows edit and delete actions to managers", %{conn: conn} do
+      org = insert!(:organization)
+      user = insert!(:user)
+      repo = insert!(:repository, user: org)
+      ticket = insert!(:ticket, repository: repo)
+      insert!(:bounty, owner: org, ticket: ticket)
+      insert!(:member, user: user, org: org, role: :mod)
+
+      conn =
+        conn
+        |> Phoenix.ConnTest.init_test_session(%{})
+        |> UserAuth.put_current_user(user)
+
+      {:ok, _view, html} = live(conn, ~p"/#{org.handle}/bounties")
+
+      assert html =~ "edit-bounty-amount"
+      assert html =~ "delete-bounty"
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- Hide bounty edit/delete controls unless the current org role can manage bounties.
- Add LiveView coverage for manager and non-manager visibility.

Fixes https://github.com/algora-io/algora/issues/238

## Verification

- Not run: mix is not available in the current Windows PATH.