### PR TITLE
Hide bounty management actions from unauthorized viewers

### DIFF
--- a/lib/algora_web/live/org/bounties_live.ex
+++ b/lib/algora_web/live/org/bounties_live.ex
@@ -219,7 +219,10 @@ defmodule AlgoraWeb.Org.BountiesLive do
                         </div>
                       <% end %>
                     </td>
-                    <td class="[&:has([role=checkbox])]:pr-0 p-4 align-middle">
+                    <td
+                      :if={can_manage_bounties?(@current_user_role)}
+                      class="[&:has([role=checkbox])]:pr-0 p-4 align-middle"
+                    >
                       <div class="flex items-center justify-end gap-2">
                         <.button
                           phx-click="edit-bounty-amount"
@@ -692,6 +695,8 @@ defmodule AlgoraWeb.Org.BountiesLive do
   end
 
   defp page_size, do: 10
+
+  defp can_manage_bounties?(role), do: role in [:admin, :mod]
 
   defp assign_bounties(socket) do
     current_org = socket.assigns.current_org

--- a/test/algora_web/live/org/bounties_live_test.exs
+++ b/test/algora_web/live/org/bounties_live_test.exs
@@ -1,0 +1,44 @@
+defmodule AlgoraWeb.Org.BountiesLiveTest do
+  use AlgoraWeb.ConnCase, async: true
+
+  import Algora.Factory
+  import Phoenix.LiveViewTest
+
+  setup %{conn: conn} do
+    repo_owner = insert!(:organization)
+    org = insert!(:organization)
+    user = insert!(:user)
+
+    repository = insert!(:repository, user: repo_owner)
+    ticket = insert!(:ticket, repository: repository)
+    insert!(:bounty, owner: org, creator: org, ticket: ticket)
+
+    %{conn: Phoenix.ConnTest.init_test_session(conn, %{}), org: org, user: user}
+  end
+
+  test "hides bounty management actions from logged-out viewers", %{conn: conn, org: org} do
+    {:ok, _view, html} = live(conn, ~p"/#{org.handle}/bounties")
+
+    refute html =~ "Edit Amount"
+    refute html =~ "Delete"
+  end
+
+  test "hides bounty management actions from non-member viewers", %{conn: conn, org: org, user: user} do
+    conn = AlgoraWeb.UserAuth.put_current_user(conn, user)
+
+    {:ok, _view, html} = live(conn, ~p"/#{org.handle}/bounties")
+
+    refute html =~ "Edit Amount"
+    refute html =~ "Delete"
+  end
+
+  test "shows bounty management actions to org moderators", %{conn: conn, org: org, user: user} do
+    insert!(:member, org: org, user: user, role: :mod)
+    conn = AlgoraWeb.UserAuth.put_current_user(conn, user)
+
+    {:ok, _view, html} = live(conn, ~p"/#{org.handle}/bounties")
+
+    assert html =~ "Edit Amount"
+    assert html =~ "Delete"
+  end
+end


### PR DESCRIPTION
## Summary
- hide bounty Edit Amount/Delete controls unless the current org role can manage bounties
- add LiveView coverage for logged-out viewers, non-member viewers, and org moderators

Fixes #238.

## Verification
- `mix deps.get`
- `mix format --check-formatted lib/algora_web/live/org/bounties_live.ex test/algora_web/live/org/bounties_live_test.exs`
- `git diff --check`
- `MIX_ENV=test mix test test/algora_web/live/org/bounties_live_test.exs` blocked before tests ran because `TEST_DATABASE_URL` is unset and the test repo config has no fallback `:database` key in this environment. The app and dependencies compiled before hitting the DB config error.