### PR TITLE
fix: open external links in new tabs

### DIFF
--- a/lib/algora_web/forms/contract_form.ex
+++ b/lib/algora_web/forms/contract_form.ex
@@ -94,6 +94,7 @@ defmodule AlgoraWeb.Forms.ContractForm do
                         :if={contractor.provider_login}
                         href={"https://github.com/#{contractor.provider_login}"}
                         target="_blank"
+                        rel="noopener"
                         class="flex items-center gap-1 hover:underline"
                       >
                         <.icon name="github" class="h-4 w-4" />
@@ -103,6 +104,7 @@ defmodule AlgoraWeb.Forms.ContractForm do
                         :if={contractor.provider_meta["twitter_handle"]}
                         href={"https://x.com/#{contractor.provider_meta["twitter_handle"]}"}
                         target="_blank"
+                        rel="noopener"
                         class="flex items-center gap-1 hover:underline"
                       >
                         <.icon name="tabler-brand-x" class="h-4 w-4" />

--- a/lib/algora_web/live/blog_live.ex
+++ b/lib/algora_web/live/blog_live.ex
@@ -76,6 +76,7 @@ defmodule AlgoraWeb.BlogLive do
                       <.link
                         href={"https://github.com/#{author}"}
                         target="_blank"
+                        rel="noopener"
                         class="text-sm hover:text-muted-foreground/80"
                       >
                         @{author}

--- a/lib/algora_web/live/challenges/golem_live.ex
+++ b/lib/algora_web/live/challenges/golem_live.ex
@@ -276,6 +276,7 @@ defmodule AlgoraWeb.Challenges.GolemLive do
                       <span class="text-base font-medium leading-7">
                         1.<a
                           target="_blank"
+                          rel="noopener"
                           class="font-semibold text-white underline"
                           href="https://share.hsforms.com/1R0dEmbBARr2VZeL9D5aExQ444dk"
                         >Sign up for the launch event</a>
@@ -286,6 +287,7 @@ defmodule AlgoraWeb.Challenges.GolemLive do
                       <span class="text-base font-medium leading-7">
                         2.<a
                           target="_blank"
+                          rel="noopener"
                           class="font-semibold text-white underline"
                           href="https://github.com/golemcloud/golem/issues/1004"
                         >Learn about the task and requirements</a>

--- a/lib/algora_web/live/org/jobs_live.ex
+++ b/lib/algora_web/live/org/jobs_live.ex
@@ -66,6 +66,7 @@ defmodule AlgoraWeb.Org.JobsLive do
                   <.link
                     href={url}
                     target="_blank"
+                    rel="noopener"
                     class="text-muted-foreground hover:text-foreground"
                   >
                     <.icon name={icon} class="size-4" />
@@ -85,7 +86,7 @@ defmodule AlgoraWeb.Org.JobsLive do
             <%= for {platform, icon} <- social_icons(),
                       url = social_link(@current_org, platform),
                       not is_nil(url) do %>
-              <.link href={url} target="_blank" class="text-muted-foreground hover:text-foreground">
+              <.link href={url} target="_blank" rel="noopener" class="text-muted-foreground hover:text-foreground">
                 <.icon name={icon} class="size-5" />
               </.link>
             <% end %>


### PR DESCRIPTION
Closes #176.

## What changed
- Opens external links in new tabs for contract forms, blog items, Golem challenge links, and org job links.
- Adds/keeps `rel="noopener"` for external targets.

## Notes
- I couldn't run `mix format` locally on this worker because `mix` is not installed here, so this is a small static patch.
