### PR TITLE
Add timezone search to user settings

### DIFF
--- a/lib/algora_web/components/timezone_select.ex
+++ b/lib/algora_web/components/timezone_select.ex
@@ -1,0 +1,66 @@
+defmodule AlgoraWeb.Components.TimezoneSelect do
+  @moduledoc false
+  use AlgoraWeb.Component
+
+  import AlgoraWeb.CoreComponents, only: [input: 1]
+
+  alias Phoenix.HTML.FormField
+
+  attr(:field, FormField, required: true)
+  attr(:label, :string, default: "Timezone")
+  attr(:query, :string, default: "")
+  attr(:query_name, :string, default: "timezone_query")
+
+  def timezone_select(assigns) do
+    assigns =
+      assign(
+        assigns,
+        :options,
+        filter_timezone_options(assigns.query, assigns.field.value)
+      )
+
+    ~H"""
+    <div class="space-y-2">
+      <.input
+        type="search"
+        name={@query_name}
+        label={"Search #{@label}"}
+        value={@query}
+        placeholder="Search by city, region, or UTC offset"
+        autocomplete="off"
+        phx-debounce="300"
+      />
+      <.input field={@field} label={@label} type="select" options={@options} />
+    </div>
+    """
+  end
+
+  defp filter_timezone_options(query, selected_timezone) do
+    query = query |> to_string() |> String.trim() |> String.downcase()
+
+    Algora.Time.list_friendly_timezones()
+    |> Enum.filter(fn {label, timezone} ->
+      query == "" or
+        String.contains?(String.downcase(label), query) or
+        String.contains?(String.downcase(timezone), query)
+    end)
+    |> include_selected_timezone(selected_timezone)
+  end
+
+  defp include_selected_timezone(options, selected_timezone)
+       when is_binary(selected_timezone) and selected_timezone != "" do
+    if Enum.any?(options, fn {_label, timezone} -> timezone == selected_timezone end) do
+      options
+    else
+      [{timezone_label(selected_timezone), selected_timezone} | options]
+    end
+  end
+
+  defp include_selected_timezone(options, _selected_timezone), do: options
+
+  defp timezone_label(timezone) do
+    Algora.Time.friendly_timezone(timezone)
+  rescue
+    _ -> timezone
+  end
+end

--- a/lib/algora_web/live/user/settings_live.ex
+++ b/lib/algora_web/live/user/settings_live.ex
@@ -4,6 +4,7 @@ defmodule AlgoraWeb.User.SettingsLive do
 
   alias Algora.Accounts
   alias Algora.Accounts.User
+  alias AlgoraWeb.Components.TimezoneSelect
 
   def render(assigns) do
     ~H"""
@@ -51,11 +52,9 @@ defmodule AlgoraWeb.User.SettingsLive do
               <.input field={@form[:bio]} type="textarea" label="Bio" />
               <.input field={@form[:website_url]} label="Website" />
               <.input field={@form[:location]} label="Location" />
-              <.input
+              <TimezoneSelect.timezone_select
                 field={@form[:timezone]}
-                label="Timezone"
-                type="select"
-                options={Algora.Time.list_friendly_timezones()}
+                query={@timezone_query}
               />
               <.button class="ml-auto">Save</.button>
             </div>
@@ -74,16 +73,20 @@ defmodule AlgoraWeb.User.SettingsLive do
     {:ok,
      socket
      |> assign(current_user: current_user)
+     |> assign(:timezone_query, "")
      |> assign_form(changeset)}
   end
 
-  def handle_event("validate", %{"user" => params}, socket) do
+  def handle_event("validate", %{"user" => params} = all_params, socket) do
     changeset =
       socket.assigns.current_user
       |> User.settings_changeset(params)
       |> Map.put(:action, :validate)
 
-    {:noreply, assign_form(socket, changeset)}
+    {:noreply,
+     socket
+     |> assign(:timezone_query, Map.get(all_params, "timezone_query", ""))
+     |> assign_form(changeset)}
   end
 
   def handle_event("save", %{"user" => params}, socket) do

--- a/test/algora_web/live/user_settings_live_test.exs
+++ b/test/algora_web/live/user_settings_live_test.exs
@@ -1,0 +1,39 @@
+defmodule AlgoraWeb.User.SettingsLiveTest do
+  use AlgoraWeb.ConnCase
+
+  import Algora.Factory
+  import Phoenix.LiveViewTest
+
+  describe "timezone selector" do
+    test "filters timezone options from a search input", %{conn: conn} do
+      user = insert(:user)
+
+      conn =
+        conn
+        |> Phoenix.ConnTest.init_test_session(%{})
+        |> AlgoraWeb.UserAuth.put_current_user(user)
+
+      {:ok, view, html} = live(conn, ~p"/user/settings")
+
+      assert html =~ "Search Timezone"
+      assert html =~ "America/Los_Angeles"
+
+      html =
+        render_change(view, :validate, %{
+          "timezone_query" => "Johannesburg",
+          "user" => %{
+            "handle" => user.handle,
+            "display_name" => user.display_name,
+            "bio" => user.bio,
+            "website_url" => user.website_url,
+            "location" => user.location,
+            "timezone" => user.timezone
+          }
+        })
+
+      assert html =~ "Africa/Johannesburg"
+      assert html =~ "America/Los_Angeles"
+      refute html =~ "Asia/Tokyo"
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- Add a searchable timezone input above the user settings timezone select
- Filter friendly timezone options by city, region, or UTC offset while keeping the current selected timezone available
- Add LiveView coverage for the filtered timezone options

Closes #152.

## Validation

- `mix format --dot-formatter C:\Users\akmha\Money\scripts\plain-elixir-formatter.exs --check-formatted lib\algora_web\components\timezone_select.ex lib\algora_web\live\user\settings_live.ex test\algora_web\live\user_settings_live_test.exs`
- `MIX_ENV=test mix compile --warnings-as-errors`
- `MIX_ENV=test mix test test/algora_web/live/user_settings_live_test.exs`
- `git diff --cached --check`
- `gitleaks detect --pipe --redact --verbose --no-color`

## Notes

- The focused WSL test logs existing ChromicPDF startup noise in this environment, but it completed with `1 test, 0 failures`.
- I did not run the full test suite.