### PR TITLE
fix(bounties): centralize bounty-manage auth via Member.can_manage_bounty? (#238)

### DIFF
--- a/lib/algora/organizations/schemas/member.ex
+++ b/lib/algora/organizations/schemas/member.ex
@@ -37,6 +37,8 @@ defmodule Algora.Organizations.Member do
 
   def can_create_bounty?(role), do: role in [:admin, :mod]
 
+  def can_manage_bounty?(role), do: role in [:admin, :mod]
+
   def can_create_contract?(role), do: role in [:admin, :mod]
 
   def can_view_matches?(org, role), do: org.contract_signed && role in [:admin, :mod]

--- a/lib/algora_web/live/org/bounties_live.ex
+++ b/lib/algora_web/live/org/bounties_live.ex
@@ -10,6 +10,7 @@ defmodule AlgoraWeb.Org.BountiesLive do
   alias Algora.Bounties.Bounty
   alias Algora.Github
   alias Algora.Markdown
+  alias Algora.Organizations.Member
   alias Algora.Payments
   alias Algora.Repo
   alias Algora.Types.USD
@@ -219,7 +220,10 @@ defmodule AlgoraWeb.Org.BountiesLive do
                         </div>
                       <% end %>
                     </td>
-                    <td class="[&:has([role=checkbox])]:pr-0 p-4 align-middle">
+                    <td
+                      :if={Member.can_manage_bounty?(@current_user_role)}
+                      class="[&:has([role=checkbox])]:pr-0 p-4 align-middle"
+                    >
                       <div class="flex items-center justify-end gap-2">
                         <.button
                           phx-click="edit-bounty-amount"
@@ -363,7 +367,12 @@ defmodule AlgoraWeb.Org.BountiesLive do
     </div>
 
     <!-- Edit Amount Drawer -->
-    <.drawer show={@show_edit_modal} direction="right" on_cancel="cancel-edit">
+    <.drawer
+      :if={Member.can_manage_bounty?(@current_user_role)}
+      show={@show_edit_modal}
+      direction="right"
+      on_cancel="cancel-edit"
+    >
       <.drawer_header>
         <.drawer_title>Edit Bounty Amount</.drawer_title>
         <.drawer_description>
@@ -415,7 +424,7 @@ defmodule AlgoraWeb.Org.BountiesLive do
 
   def handle_event("delete-bounty", %{"id" => bounty_id}, socket) do
     cond do
-      socket.assigns.current_user_role in [:admin, :mod] ->
+      Member.can_manage_bounty?(socket.assigns.current_user_role) ->
         bounty =
           Bounty
           |> Repo.get(bounty_id)
@@ -475,7 +484,7 @@ defmodule AlgoraWeb.Org.BountiesLive do
 
   def handle_event("edit-bounty-amount", %{"id" => bounty_id}, socket) do
     cond do
-      socket.assigns.current_user_role in [:admin, :mod] ->
+      Member.can_manage_bounty?(socket.assigns.current_user_role) ->
         [bounty] = Bounties.list_bounties(id: bounty_id)
         changeset = edit_amount_changeset(%{amount: bounty.amount})
 


### PR DESCRIPTION
## Summary

fix(bounties): hide manage-bounty actions from unauthorized users




## Diff

```
 lib/algora/organizations/schemas/member.ex |  2 ++
 lib/algora_web/live/org/bounties_live.ex   | 17 +++++++++++++----
 2 files changed, 15 insertions(+), 4 deletions(-)
```

## Claim

/claim #238
