### PR TITLE
feat: show relative time on bounty list items

### DIFF
--- a/lib/algora_web/components/bounties.ex
+++ b/lib/algora_web/components/bounties.ex
@@ -35,6 +35,12 @@ defmodule AlgoraWeb.Components.Bounties do
                     {Money.to_string!(bounty.amount)}
                   </span>
                   <span class="text-foreground">{bounty.ticket.title}</span>
+                  <span
+                    :if={bounty.inserted_at}
+                    class="ml-auto pl-2 whitespace-nowrap text-xs tabular-nums text-muted-foreground"
+                  >
+                    {Algora.Util.relative_time(bounty.inserted_at)}
+                  </span>
                 </div>
               </div>
             </li>


### PR DESCRIPTION
## Summary

The `relative_time` util landed recently but the bounty list component (`lib/algora_web/components/bounties.ex`) didn't wire it up. Adds the call site so each bounty card shows "3 hours ago" / "yesterday" alongside the amount.

## Why this matters

#175 asks for time context on the bounty list. The util to render it already exists; this PR is just the wiring.

## Changes

- `lib/algora_web/components/bounties.ex` - render `relative_time(@bounty.inserted_at)` in a secondary span next to the amount.

Fixes #175
