### PR TITLE
fix: hide Edit/Delete buttons for non-admin users on bounties page

### DIFF
--- a/lib/algora/bounties/bounties.ex
+++ b/lib/algora/bounties/bounties.ex
@@ -1382,7 +1382,7 @@ defmodule Algora.Bounties do
     base_query()
     |> list_bounties_query(Keyword.put(criteria, :limit, :infinity))
     |> where([b, r: r], not is_nil(r.tech_stack))
-    |> join(:cross_lateral, [b, r: r], tech in fragment("SELECT UNNEST(?) as tech", r.tech_stack), as: :tech)
+    |> join(:cross_lateral, [b, r: r], tech in fragment("SELECT UNNEST(r.tech_stack) as tech"), as: :tech)
     |> group_by([b, r: r, tech: tech], fragment("tech"))
     |> select([b, r: r, tech: tech], {fragment("tech"), count(fragment("tech"))})
     |> order_by([b, r: r, tech: tech], desc: count(fragment("tech")))

--- a/lib/algora/jobs/jobs.ex
+++ b/lib/algora/jobs/jobs.ex
@@ -221,6 +221,13 @@ defmodule Algora.Jobs do
     |> MapSet.new()
   end
 
+  def withdraw_application(job_id, user) do
+    case JobApplication |> where([a], a.job_id == ^job_id and a.user_id == ^user.id) |> Repo.one() do
+      nil -> {:error, :not_found}
+      application -> Repo.delete(application)
+    end
+  end
+
   def get_job_posting(id) do
     case JobPosting |> Repo.get(id) |> Repo.preload(:user) do
       nil -> {:error, :not_found}

--- a/lib/algora_web/components/bounties.ex
+++ b/lib/algora_web/components/bounties.ex
@@ -36,6 +36,9 @@ defmodule AlgoraWeb.Components.Bounties do
                   </span>
                   <span class="text-foreground">{bounty.ticket.title}</span>
                 </div>
+                <div class="text-xs text-muted-foreground">
+                  {Algora.Util.time_ago(bounty.inserted_at)}
+                </div>
               </div>
             </li>
           </.link>

--- a/lib/algora_web/controllers/user_auth.ex
+++ b/lib/algora_web/controllers/user_auth.ex
@@ -238,7 +238,14 @@ defmodule AlgoraWeb.UserAuth do
     end
   end
 
-  def signed_in_path_from_context(org_handle), do: ~p"/#{org_handle}/dashboard"
+  def signed_in_path_from_context(org_handle) do
+    # Handle case where last_context is an old provider_login (GitHub username)
+    # that no longer exists as a user/org handle
+    case Repo.get_by(User, handle: org_handle) do
+      nil -> ~p"/home"
+      _user_or_org -> ~p"/#{org_handle}/dashboard"
+    end
+  end
 
   def signed_in_path(%User{} = user) do
     signed_in_path_from_context(Accounts.last_context(user))

--- a/lib/algora_web/controllers/webhooks/github_controller.ex
+++ b/lib/algora_web/controllers/webhooks/github_controller.ex
@@ -505,7 +505,7 @@ defmodule AlgoraWeb.Webhooks.GithubController do
   end
 
   defp execute_command(%Webhook{event_action: event_action, author: author, payload: payload}, {:attempt, args})
-       when event_action in ["issue_comment.created", "issue_comment.edited"] do
+       when event_action == "issue_comment.created" do
     source_ticket_ref = %{
       owner: payload["repository"]["owner"]["login"],
       repo: payload["repository"]["name"],

--- a/lib/algora_web/endpoint.ex
+++ b/lib/algora_web/endpoint.ex
@@ -119,12 +119,12 @@ defmodule AlgoraWeb.Endpoint do
   end
 
   defp path_for_subdomain(sub, conn) do
+    # Lower alert severity to prevent alert spamming from subdomain enumeration
+    # (bug bounty scanners, automated tools, etc.)
     case Algora.Accounts.get_user_by_handle(sub) do
-      nil ->
-        conn.request_path
-
+      nil -> conn.request_path
       _user ->
-        Algora.Activities.alert("👀 Someone is viewing https://#{sub}.algora.io", :critical)
+        Algora.Activities.alert("👀 Someone is viewing https://#{sub}.algora.io", :info)
         Path.join(["/#{sub}/candidates", conn.request_path])
     end
   end

--- a/lib/algora_web/live/jobs_live.ex
+++ b/lib/algora_web/live/jobs_live.ex
@@ -143,8 +143,8 @@ defmodule AlgoraWeb.JobsLive do
                           </div>
                         </div>
                         <%= if MapSet.member?(@user_applications, job.id) do %>
-                          <.button disabled class="opacity-50">
-                            <.icon name="tabler-check" class="h-4 w-4 mr-2 -ml-1" /> Applied
+                          <.button phx-click="withdraw_job" phx-value-job-id={job.id} variant="secondary">
+                            <.icon name="tabler-x" class="h-4 w-4 mr-2 -ml-1" /> Withdraw
                           </.button>
                         <% else %>
                           <.button phx-click="apply_job" phx-value-job-id={job.id}>
@@ -544,6 +544,21 @@ defmodule AlgoraWeb.JobsLive do
         end
       else
         {:noreply, redirect(socket, external: Algora.Github.authorize_url(%{return_to: "/jobs"}))}
+      end
+    else
+      {:noreply, redirect(socket, external: Algora.Github.authorize_url(%{return_to: "/jobs"}))}
+    end
+  end
+
+  @impl true
+  def handle_event("withdraw_job", %{"job-id" => job_id}, socket) do
+    if socket.assigns[:current_user] do
+      case Jobs.withdraw_application(job_id, socket.assigns.current_user) do
+        {:ok, _} ->
+          {:noreply, assign_user_applications(socket) |> put_flash(:info, "Application withdrawn")}
+
+        {:error, _} ->
+          {:noreply, put_flash(socket, :error, "Failed to withdraw application. Please try again.")}
       end
     else
       {:noreply, redirect(socket, external: Algora.Github.authorize_url(%{return_to: "/jobs"}))}

--- a/lib/algora_web/live/org/bounties_live.ex
+++ b/lib/algora_web/live/org/bounties_live.ex
@@ -220,7 +220,7 @@ defmodule AlgoraWeb.Org.BountiesLive do
                       <% end %>
                     </td>
                     <td class="[&:has([role=checkbox])]:pr-0 p-4 align-middle">
-                      <div class="flex items-center justify-end gap-2">
+                      <div :if={@current_user_role in [:admin, :mod]} class="flex items-center justify-end gap-2">
                         <.button
                           phx-click="edit-bounty-amount"
                           phx-value-id={bounty.id}


### PR DESCRIPTION
## Summary

Fix 7 bugs reported by users:

1. **#238** - UI Bug: Hide Edit/Delete buttons for non-admin users on bounties page
2. **#183** - Bug: Redirect to /home when last_context references non-existent user (GitHub username change)
3. **#201** - Security: Lower alert severity from :critical to :info to prevent subdomain enumeration spam
4. **#175** - Feature: Show time info ('posted X ago') on bounty list items
5. **#141** - Bug: Bot re-processes /attempt commands when comments are edited, causing duplicate responses
6. **#171** - Feature: Add withdraw functionality for job applications
7. **#173** - Bug: Fix incorrect tech stack count on bounties page

## Changes

- `lib/algora_web/live/org/bounties_live.ex`: Add permission check for Edit/Delete buttons
- `lib/algora_web/controllers/user_auth.ex`: Validate handle exists before redirect
- `lib/algora_web/endpoint.ex`: Change alert severity to :info
- `lib/algora_web/components/bounties.ex`: Add time_ago display
- `lib/algora_web/controllers/webhooks/github_controller.ex`: Only process /attempt on comment creation
- `lib/algora/jobs/jobs.ex`: Add withdraw_application function
- `lib/algora_web/live/jobs_live.ex`: Add withdraw_job event handler and button

## Test plan

- [ ] #238: Verify buttons hidden for non-admin, visible for admin
- [ ] #183: Login with user who changed GitHub username, verify redirect to /home
- [ ] #201: Check alert system doesn't spam from subdomain enumeration
- [ ] #175: Verify 'posted X ago' appears on bounties
- [ ] #141: Edit a comment with /attempt, verify no duplicate response
- [ ] #171: Apply to a job, then withdraw, verify button changes
- [ ] #173: Check tech stack counts on /bounties page are correct

Fixes #238
Fixes #183
Fixes #201
Fixes #175
Fixes #141
Fixes #171
Fixes #173