### PR TITLE
Hide bounty actions from unauthorized users

### DIFF
--- a/lib/algora_web/live/org/bounties_live.ex
+++ b/lib/algora_web/live/org/bounties_live.ex
@@ -220,7 +220,10 @@ defmodule AlgoraWeb.Org.BountiesLive do
                       <% end %>
                     </td>
                     <td class="[&:has([role=checkbox])]:pr-0 p-4 align-middle">
-                      <div class="flex items-center justify-end gap-2">
+                      <div
+                        :if={@current_user_role in [:admin, :mod]}
+                        class="flex items-center justify-end gap-2"
+                      >
                         <.button
                           phx-click="edit-bounty-amount"
                           phx-value-id={bounty.id}


### PR DESCRIPTION
Fixes #238.\n\n## Summary\n- only render bounty Edit Amount/Delete controls for org admins/mods\n- keeps existing server-side authorization checks intact\n\n## Testing\n- Not run (mix unavailable in environment: `mix: command not found`)