### PR TITLE
Fix tech stack filtering for exclusive bounties

### DIFF
--- a/lib/algora/bounties/bounties.ex
+++ b/lib/algora/bounties/bounties.ex
@@ -1269,7 +1269,7 @@ defmodule Algora.Bounties do
 
       {:tech_stack, tech_stack}, query ->
         from([b, r: r] in query,
-          where: b.visibility == :exclusive or fragment("? && ?::citext[]", r.tech_stack, ^tech_stack)
+          where: fragment("? && ?::citext[]", r.tech_stack, ^tech_stack)
         )
 
       {:amount_gt, min_amount}, query ->

--- a/test/algora/bounties_test.exs
+++ b/test/algora/bounties_test.exs
@@ -658,6 +658,46 @@ defmodule Algora.BountiesTest do
       assert Enum.any?(bounties, &(&1.status == :paid))
       refute Enum.any?(bounties, &(&1.status == :cancelled))
     end
+
+    test "tech stack filter excludes visible bounties from other stacks" do
+      viewer = insert!(:user)
+      featured_owner = insert!(:user, featured: true)
+      private_owner = insert!(:user)
+
+      svelte_repo = insert!(:repository, user: featured_owner, tech_stack: ["Svelte"])
+      rust_repo = insert!(:repository, user: private_owner, tech_stack: ["Rust"])
+
+      svelte_ticket = insert!(:ticket, repository: svelte_repo)
+      rust_ticket = insert!(:ticket, repository: rust_repo)
+
+      svelte_bounty =
+        insert!(:bounty,
+          status: :open,
+          visibility: :public,
+          ticket: svelte_ticket,
+          owner: featured_owner
+        )
+
+      rust_bounty =
+        insert!(:bounty,
+          status: :open,
+          visibility: :exclusive,
+          shared_with: [viewer.id],
+          ticket: rust_ticket,
+          owner: private_owner
+        )
+
+      bounties =
+        Bounties.list_bounties(
+          status: :open,
+          current_user: viewer,
+          tech_stack: ["svelte"],
+          limit: :infinity
+        )
+
+      assert Enum.any?(bounties, &(&1.id == svelte_bounty.id))
+      refute Enum.any?(bounties, &(&1.id == rust_bounty.id))
+    end
   end
 
   describe "list_claims/1" do


### PR DESCRIPTION
Closes #173.

Summary:
- apply the selected tech stack filter to exclusive bounties instead of letting them bypass it
- add a regression test covering a visible Rust exclusive bounty being excluded from a Svelte filtered listing

Validation:
- `mix format --check-formatted lib/algora/bounties/bounties.ex test/algora/bounties_test.exs`
- `mix compile --warnings-as-errors`
- `TEST_DATABASE_URL=ecto://postgres@localhost:55432/algora_test mix test test/algora/bounties_test.exs` (20 tests, 0 failures)
- `git diff --check`
- `git diff -- lib/algora/bounties/bounties.ex test/algora/bounties_test.exs | gitleaks stdin --no-banner --redact --timeout 30`

Notes:
- Repo-wide `mix format --check-formatted` reports unrelated existing formatting differences under this local Elixir 1.19.5 / Erlang OTP 28 setup; the changed-file formatter check passes.
- The targeted test run emitted unrelated Oban sandbox and ChromicPDF startup logs, but ExUnit completed successfully with 20 tests and 0 failures.