### PR TITLE
fix: ignore unchanged bounty comment edits

### DIFF
--- a/lib/algora_web/controllers/webhooks/github_controller.ex
+++ b/lib/algora_web/controllers/webhooks/github_controller.ex
@@ -116,8 +116,7 @@ defmodule AlgoraWeb.Webhooks.GithubController do
   defp process_event(
          %Webhook{event_action: "pull_request.closed", payload: %{"pull_request" => %{"merged_at" => nil}}} = webhook,
          _commands
-       ),
-       do: handle_ticket_state_change(webhook)
+       ), do: handle_ticket_state_change(webhook)
 
   defp process_event(%Webhook{event_action: "pull_request.closed", payload: payload} = webhook, _commands) do
     _res = handle_ticket_state_change(webhook)
@@ -325,7 +324,11 @@ defmodule AlgoraWeb.Webhooks.GithubController do
         "pull_request" -> {:ticket, payload["pull_request"]["id"]}
       end
 
-    ticket_number = get_github_ticket(webhook)["number"]
+    ticket_ref = %{
+      owner: payload["repository"]["owner"]["login"],
+      repo: payload["repository"]["name"],
+      number: get_github_ticket(webhook)["number"]
+    }
 
     strategy = :set
     # strategy =
@@ -349,22 +352,22 @@ defmodule AlgoraWeb.Webhooks.GithubController do
            ),
          {:ok, owner} <- Accounts.fetch_user_by(id: installation.connected_user_id),
          {:ok, creator} <- Workspace.ensure_user(token, author["login"]) do
-      Bounties.create_bounty(
-        %{
-          creator: creator,
-          owner: owner,
-          amount: amount,
-          ticket_ref: %{
-            owner: payload["repository"]["owner"]["login"],
-            repo: payload["repository"]["name"],
-            number: ticket_number
-          }
-        },
-        strategy: strategy,
-        installation_id: payload["installation"]["id"],
-        command_id: command_id,
-        command_source: command_source
-      )
+      if unchanged_bounty_edit?(webhook, owner, amount, token, ticket_ref) do
+        {:ok, :unchanged}
+      else
+        Bounties.create_bounty(
+          %{
+            creator: creator,
+            owner: owner,
+            amount: amount,
+            ticket_ref: ticket_ref
+          },
+          strategy: strategy,
+          installation_id: payload["installation"]["id"],
+          command_id: command_id,
+          command_source: command_source
+        )
+      end
     else
       false ->
         {:error, :unauthorized}
@@ -590,6 +593,21 @@ defmodule AlgoraWeb.Webhooks.GithubController do
 
     {:error, :unknown_command}
   end
+
+  defp unchanged_bounty_edit?(%Webhook{event_action: "issue_comment.edited"}, owner, amount, token, %{
+         owner: repo_owner,
+         repo: repo_name,
+         number: number
+       }) do
+    with {:ok, ticket} <- Workspace.ensure_ticket(token, repo_owner, repo_name, number),
+         %Bounty{} = bounty <- Repo.get_by(Bounty, owner_id: owner.id, ticket_id: ticket.id) do
+      Money.equal?(bounty.amount, amount)
+    else
+      _ -> false
+    end
+  end
+
+  defp unchanged_bounty_edit?(_webhook, _owner, _amount, _token, _ticket_ref), do: false
 
   def build_command({:claim, args}, commands) do
     splits = Keyword.get_values(commands, :split)

--- a/test/algora_web/controllers/webhooks/github_controller_test.exs
+++ b/test/algora_web/controllers/webhooks/github_controller_test.exs
@@ -163,6 +163,34 @@ defmodule AlgoraWeb.Webhooks.GithubControllerTest do
       assert Money.equal?(Repo.one(Bounty).amount, ~M[200]usd)
     end
 
+    test "does not enqueue another bounty response when editing unchanged bounty comment text", ctx do
+      comment_id = :rand.uniform(1000)
+
+      process_scenario!(ctx, [
+        %{
+          event_action: "issue_comment.created",
+          user_type: :repo_admin,
+          body: "/bounty $100",
+          params: %{"comment" => %{"id" => comment_id}}
+        }
+      ])
+
+      assert Money.equal?(Repo.one(Bounty).amount, ~M[100]usd)
+      assert [_job] = all_enqueued(worker: NotifyBounty)
+
+      process_scenario!(ctx, [
+        %{
+          event_action: "issue_comment.edited",
+          user_type: :repo_admin,
+          body: "/bounty $100\n\nAdding extra details without changing the bounty.",
+          params: %{"comment" => %{"id" => comment_id}}
+        }
+      ])
+
+      assert Money.equal?(Repo.one(Bounty).amount, ~M[100]usd)
+      assert [_job] = all_enqueued(worker: NotifyBounty)
+    end
+
     test "overrides bounty amount when creating a new bounty comment", ctx do
       comment_id = :rand.uniform(1000)
 


### PR DESCRIPTION
## Summary
- skip enqueueing another bounty response when an edited `/bounty` comment keeps the same amount
- keep real bounty amount edits working while allowing users to add context to the original comment without another bot response

Fixes #141

## Validation
- `TEST_DATABASE_URL=postgresql://postgres:postgres@localhost:5432/postgres mix test test/algora_web/controllers/webhooks/github_controller_test.exs:166 --trace` - 1 test, 0 failures
- `TEST_DATABASE_URL=postgresql://postgres:postgres@localhost:5432/postgres mix test test/algora_web/controllers/webhooks/github_controller_test.exs:137 --trace` - 1 test, 0 failures
- `mix format --check-formatted lib/algora_web/controllers/webhooks/github_controller.ex test/algora_web/controllers/webhooks/github_controller_test.exs`
- `git diff HEAD~1..HEAD --check`
- `git show HEAD | gitleaks detect --pipe --redact --no-banner` - no leaks found

Note: I also attempted the full webhook controller test file locally with `--max-cases 1`; it failed before assertions with Oban/Ecto sandbox ownership errors from background Oban processes, so I validated the changed regression and existing amount-edit path independently.