### PR TITLE
Add legacy profile route redirect

### DIFF
--- a/lib/algora_web/controllers/user_controller.ex
+++ b/lib/algora_web/controllers/user_controller.ex
@@ -5,6 +5,14 @@ defmodule AlgoraWeb.UserController do
   alias Algora.Repo
 
   def index(conn, %{"handle" => handle}) do
+    redirect_to_handle(conn, handle)
+  end
+
+  def profile(conn, %{"handle" => handle}) do
+    redirect_to_handle(conn, handle)
+  end
+
+  defp redirect_to_handle(conn, handle) do
     user = Repo.get_by(User, handle: handle)
 
     case user do

--- a/lib/algora_web/router.ex
+++ b/lib/algora_web/router.ex
@@ -245,6 +245,8 @@ defmodule AlgoraWeb.Router do
   scope "/", AlgoraWeb do
     pipe_through [:browser]
 
+    get "/profile/:handle", UserController, :profile
+
     scope "/:repo_owner/:repo_name" do
       get "/", RepoController, :index
 

--- a/test/algora_web/controllers/user_controller_test.exs
+++ b/test/algora_web/controllers/user_controller_test.exs
@@ -1,0 +1,27 @@
+defmodule AlgoraWeb.UserControllerTest do
+  use AlgoraWeb.ConnCase
+
+  import Algora.Factory
+
+  test "redirects legacy profile paths for individuals", %{conn: conn} do
+    user = insert(:user)
+
+    conn = get(conn, "/profile/#{user.handle}")
+
+    assert redirected_to(conn) == "/#{user.handle}/profile"
+  end
+
+  test "redirects legacy profile paths for organizations", %{conn: conn} do
+    org = insert(:organization)
+
+    conn = get(conn, "/profile/#{org.handle}")
+
+    assert redirected_to(conn) == "/#{org.handle}/dashboard"
+  end
+
+  test "raises not found for unknown legacy profile handles", %{conn: conn} do
+    assert_raise AlgoraWeb.NotFoundError, fn ->
+      get(conn, "/profile/missing-profile-handle")
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- route `/profile/:handle` through the same handle redirect logic used by `/:handle`
- keep individual users going to `/:handle/profile` and organizations to `/:handle/dashboard`
- add controller coverage for individual, organization, and unknown handles

Fixes #209

## Validation
- `TEST_DATABASE_URL=postgresql://postgres:postgres@localhost:5432/algora_test mix test test/algora_web/controllers/user_controller_test.exs` (3 tests, 0 failures)
- `mix format --check-formatted lib/algora_web/controllers/user_controller.ex lib/algora_web/router.ex test/algora_web/controllers/user_controller_test.exs`
- `git diff --check HEAD~1..HEAD`
- `git diff HEAD~1..HEAD | gitleaks detect --pipe --no-banner --redact` (no leaks)