### PR TITLE
Fix tech-stack bounty filtering on /bounties/:tech pages

### DIFF
--- a/lib/algora/bounties/bounties.ex
+++ b/lib/algora/bounties/bounties.ex
@@ -1268,8 +1268,8 @@ defmodule Algora.Bounties do
         query
 
       {:tech_stack, tech_stack}, query ->
-        from([b, r: r] in query,
-          where: b.visibility == :exclusive or fragment("? && ?::citext[]", r.tech_stack, ^tech_stack)
+        from([_b, r: r] in query,
+          where: fragment("? && ?::citext[]", r.tech_stack, ^tech_stack)
         )
 
       {:amount_gt, min_amount}, query ->

--- a/test/algora/bounties_test.exs
+++ b/test/algora/bounties_test.exs
@@ -658,6 +658,36 @@ defmodule Algora.BountiesTest do
       assert Enum.any?(bounties, &(&1.status == :paid))
       refute Enum.any?(bounties, &(&1.status == :cancelled))
     end
+
+    test "filters tech pages by repository tech stack instead of exclusive visibility" do
+      svelte_repo = insert!(:repository, %{user: insert!(:user), tech_stack: ["Svelte"]})
+      rust_repo = insert!(:repository, %{user: insert!(:user), tech_stack: ["Rust"]})
+
+      svelte_ticket = insert!(:ticket, %{repository: svelte_repo})
+      rust_ticket = insert!(:ticket, %{repository: rust_repo})
+
+      matching_bounty = insert!(:bounty, ticket: svelte_ticket, owner: insert!(:user), visibility: :public)
+      _unrelated_exclusive_bounty = insert!(:bounty, ticket: rust_ticket, owner: insert!(:user), visibility: :exclusive)
+
+      bounties = Bounties.list_bounties(tech_stack: ["Svelte"])
+
+      assert Enum.map(bounties, & &1.id) == [matching_bounty.id]
+    end
+  end
+
+  describe "list_tech/1" do
+    test "counts only bounties whose repository matches the selected tech stack" do
+      svelte_repo = insert!(:repository, %{user: insert!(:user), tech_stack: ["Svelte"]})
+      rust_repo = insert!(:repository, %{user: insert!(:user), tech_stack: ["Rust"]})
+
+      svelte_ticket = insert!(:ticket, %{repository: svelte_repo})
+      rust_ticket = insert!(:ticket, %{repository: rust_repo})
+
+      insert!(:bounty, ticket: svelte_ticket, owner: insert!(:user), visibility: :public)
+      insert!(:bounty, ticket: rust_ticket, owner: insert!(:user), visibility: :exclusive)
+
+      assert Bounties.list_tech(tech_stack: ["Svelte"]) == [{"Svelte", 1}]
+    end
   end
 
   describe "list_claims/1" do


### PR DESCRIPTION
# PR draft for algora-io/algora#173

## Title
Fix tech-stack bounty filtering on `/bounties/:tech` pages

## Body
Closes #173

## Summary
This fixes tech-stack filtered bounty pages showing unrelated exclusive bounties.

The root cause was the `{:tech_stack, tech_stack}` branch in `Algora.Bounties`:
- it matched repositories whose `repository.tech_stack` overlaps the requested tech stack
- but it also let any `:exclusive` bounty through, even when its repository tech stack did not match

That made pages like `/bounties/svelte` show unrelated exclusive Rust bounties while the badge/count still suggested a much smaller result set.

## Changes
- remove the `b.visibility == :exclusive` bypass from the `{:tech_stack, tech_stack}` filter path in `lib/algora/bounties/bounties.ex`
- add a regression test proving `list_bounties(tech_stack: ["Svelte"])` excludes an unrelated exclusive Rust bounty
- add a regression test proving `list_tech(tech_stack: ["Svelte"])` returns only `{"Svelte", 1}` for the same setup

## Repro
Before:
- create a public Svelte bounty and an exclusive Rust bounty
- call `Bounties.list_bounties(tech_stack: ["Svelte"])`
- the exclusive Rust bounty leaks into the Svelte-filtered results

After:
- only bounties whose repository tech stack overlaps `Svelte` are returned
- `list_tech/1` count output stays aligned with the filtered results

## Validation
Validated locally with:
```bash
TEST_DATABASE_URL='ecto://postgres:postgres@localhost:15432/algora_test' mix test test/algora/bounties_test.exs
```

Result:
- `21 tests, 0 failures`
