### PR TITLE
Fix profile contribution links for grouped repos

### DIFF
--- a/lib/algora_web/live/user/profile_live.ex
+++ b/lib/algora_web/live/user/profile_live.ex
@@ -236,7 +236,7 @@ defmodule AlgoraWeb.User.ProfileLive do
               <h2 class="text-lg font-semibold">Top Contributions</h2>
               <%= for {owner, contributions} <- aggregate_contributions(@contributions) do %>
                 <.link
-                  href={"https://github.com/#{owner.provider_login}/#{List.first(contributions).repository.name}/pulls?q=author%3A#{@user.provider_login}+is%3Amerged+"}
+                  href={contribution_search_url(owner, @user)}
                   target="_blank"
                   rel="noopener"
                   class="flex items-center gap-3 rounded-xl pr-2 bg-card/50 border border-border/50 hover:border-border transition-all group"
@@ -344,5 +344,12 @@ defmodule AlgoraWeb.User.ProfileLive do
     contributions
     |> Enum.map(& &1.contribution_count)
     |> Enum.sum()
+  end
+
+  defp contribution_search_url(owner, user) do
+    scope = if owner.type in [:organization, "organization"], do: "org", else: "user"
+    query = "author:#{user.provider_login} is:merged #{scope}:#{owner.provider_login}"
+
+    "https://github.com/pulls?q=#{URI.encode_www_form(query)}"
   end
 end

--- a/test/algora_web/live/user/profile_live_test.exs
+++ b/test/algora_web/live/user/profile_live_test.exs
@@ -1,0 +1,39 @@
+defmodule AlgoraWeb.User.ProfileLiveTest do
+  use AlgoraWeb.ConnCase, async: false
+
+  import Algora.Factory
+  import Phoenix.LiveViewTest
+
+  alias Algora.Repo
+  alias Algora.Workspace.UserContribution
+
+  test "links organization contribution cards to owner-wide pull search", %{conn: conn} do
+    user = insert(:user, handle: "contributor", provider_login: "contributor")
+    org = insert(:organization, display_name: "Transloadit", provider_login: "transloadit")
+
+    repo_a = insert(:repository, user_id: org.id, name: "uppy", tech_stack: ["TypeScript"], stargazers_count: 500)
+
+    repo_b =
+      insert(:repository, user_id: org.id, name: "tus-js-client", tech_stack: ["TypeScript"], stargazers_count: 250)
+
+    insert_contribution!(user, repo_a, 2)
+    insert_contribution!(user, repo_b, 3)
+
+    {:ok, _view, html} = live(conn, ~p"/#{user.handle}/profile")
+    assert html =~ "Transloadit"
+    assert html =~ "github.com/pulls"
+    assert html =~ "author%3Acontributor+is%3Amerged+org%3Atransloadit"
+    refute html =~ "github.com/transloadit/uppy/pulls"
+  end
+
+  defp insert_contribution!(user, repository, contribution_count) do
+    %UserContribution{}
+    |> UserContribution.changeset(%{
+      user_id: user.id,
+      repository_id: repository.id,
+      contribution_count: contribution_count,
+      last_fetched_at: DateTime.utc_now()
+    })
+    |> Repo.insert!()
+  end
+end


### PR DESCRIPTION
Fixes #168.

## Summary
- Link profile contribution cards to an owner-scoped GitHub merged-PR search instead of the first repository in the owner group.
- Add a LiveView regression covering two repositories under the same organization owner.

## Validation
- `TEST_DATABASE_URL=postgresql://postgres:postgres@localhost:15432/algora_test mix test test/algora_web/live/user/profile_live_test.exs` (`1 test, 0 failures`; local run still prints existing Oban sandbox shutdown logs after ExUnit completes)
- `mix format --check-formatted lib/algora_web/live/user/profile_live.ex test/algora_web/live/user/profile_live_test.exs`
- `git diff --check`
- `git diff HEAD~1..HEAD | gitleaks detect --pipe --no-banner --redact`