### PR TITLE
Fix #238: Hide Edit and Delete buttons for unauthorized users on bounties page

### DIFF
--- a/lib/algora_web/live/org/bounties_live.ex
+++ b/lib/algora_web/live/org/bounties_live.ex
@@ -221,6 +221,7 @@ defmodule AlgoraWeb.Org.BountiesLive do
                     </td>
                     <td class="[&:has([role=checkbox])]:pr-0 p-4 align-middle">
                       <div class="flex items-center justify-end gap-2">
+                        <%= if @current_user_role in [:admin, :mod] do %>
                         <.button
                           phx-click="edit-bounty-amount"
                           phx-value-id={bounty.id}
@@ -237,6 +238,7 @@ defmodule AlgoraWeb.Org.BountiesLive do
                         >
                           Delete
                         </.button>
+                        <% end %>
                       </div>
                     </td>
                   </tr>


### PR DESCRIPTION
This fixes the UI bug reported in #238 by hiding the "Edit Amount" and "Delete" buttons on the `/bounties` page if the user is not an admin or mod. The backend correctly prevented unauthorized usage, but these buttons remained visible to standard users leading to confusion.