### PR TITLE
fix: show profile contributions per repository (#168)

### DIFF
--- a/lib/algora_web/live/user/profile_live.ex
+++ b/lib/algora_web/live/user/profile_live.ex
@@ -234,28 +234,22 @@ defmodule AlgoraWeb.User.ProfileLive do
               <% end %>
             <% else %>
               <h2 class="text-lg font-semibold">Top Contributions</h2>
-              <%= for {owner, contributions} <- aggregate_contributions(@contributions) do %>
+              <%= for {repo, contributions} <- aggregate_contributions(@contributions) do %>
                 <.link
-                  href={"https://github.com/#{owner.provider_login}/#{List.first(contributions).repository.name}/pulls?q=author%3A#{@user.provider_login}+is%3Amerged+"}
+                  href={"https://github.com/#{repo.user.provider_login}/#{repo.name}/pulls?q=author%3A#{@user.provider_login}+is%3Amerged+"}
                   target="_blank"
                   rel="noopener"
                   class="flex items-center gap-3 rounded-xl pr-2 bg-card/50 border border-border/50 hover:border-border transition-all group"
                 >
                   <img
-                    src={owner.avatar_url}
+                    src={repo.user.avatar_url}
                     class="h-12 w-12 rounded-xl rounded-r-none  transition-all"
-                    alt={owner.name}
+                    alt={repo.user.name}
                   />
                   <div class="w-full flex flex-col text-xs font-medium gap-0.5">
                     <span class="flex items-start justify-between gap-5">
-                      <span class="font-display">
-                        {if owner.type == :organization do
-                          owner.name
-                        else
-                          List.first(contributions).repository.name
-                        end}
-                      </span>
-                      <%= if tech = List.first(List.first(contributions).repository.tech_stack) do %>
+                      <span class="font-display">{repo.name}</span>
+                      <%= if tech = List.first(repo.tech_stack) do %>
                         <.tech_badge
                           variant="ghost"
                           class="saturate-0 text-[11px] group-hover:saturate-100 transition-all"
@@ -267,7 +261,7 @@ defmodule AlgoraWeb.User.ProfileLive do
                       <span class="flex items-center text-amber-300 text-xs">
                         <.icon name="tabler-star-filled" class="h-4 w-4 mr-1" />
                         {Algora.Util.format_number_compact(
-                          max(owner.stargazers_count, total_stars(contributions))
+                          max(repo.user.stargazers_count, total_stars(contributions))
                         )}
                       </span>
                       <span class="flex items-center text-purple-400 text-xs">
@@ -327,11 +321,11 @@ defmodule AlgoraWeb.User.ProfileLive do
   end
 
   defp aggregate_contributions(contributions) do
-    groups = Enum.group_by(contributions, fn c -> c.repository.user end)
+    groups = Enum.group_by(contributions, fn c -> c.repository.id end)
 
     contributions
-    |> Enum.map(fn c -> {c.repository.user, groups[c.repository.user]} end)
-    |> Enum.uniq_by(fn {owner, _} -> owner.id end)
+    |> Enum.map(fn c -> {c.repository, groups[c.repository.id]} end)
+    |> Enum.uniq_by(fn {repo, _} -> repo.id end)
   end
 
   defp total_stars(contributions) do

--- a/test/algora_web/live/user_profile_live_test.exs
+++ b/test/algora_web/live/user_profile_live_test.exs
@@ -1,0 +1,44 @@
+defmodule AlgoraWeb.User.ProfileLiveTest do
+  use AlgoraWeb.ConnCase, async: true
+
+  import Algora.Factory
+  import Phoenix.LiveViewTest
+
+  alias Algora.Repo
+  alias Algora.Workspace.UserContribution
+
+  test "lists top contributions per repository instead of collapsing them by owner", %{conn: conn} do
+    user = insert!(:user, handle: "dev-user", provider_login: "dev-user")
+    org = insert!(:organization, provider_login: "acme-org", stargazers_count: 50)
+
+    repo_one = insert!(:repository, user: org, name: "repo-one", tech_stack: ["Elixir"], stargazers_count: 10)
+    repo_two = insert!(:repository, user: org, name: "repo-two", tech_stack: ["Rust"], stargazers_count: 20)
+
+    Repo.insert!(
+      UserContribution.changeset(%UserContribution{}, %{
+        user_id: user.id,
+        repository_id: repo_one.id,
+        contribution_count: 3,
+        last_fetched_at: DateTime.utc_now(),
+        status: :initial
+      })
+    )
+
+    Repo.insert!(
+      UserContribution.changeset(%UserContribution{}, %{
+        user_id: user.id,
+        repository_id: repo_two.id,
+        contribution_count: 5,
+        last_fetched_at: DateTime.utc_now(),
+        status: :initial
+      })
+    )
+
+    {:ok, _view, html} = live(conn, "/#{user.handle}")
+
+    assert html =~ "repo-one"
+    assert html =~ "repo-two"
+    assert html =~ "https://github.com/acme-org/repo-one/pulls?q=author%3Adev-user+is%3Amerged+"
+    assert html =~ "https://github.com/acme-org/repo-two/pulls?q=author%3Adev-user+is%3Amerged+"
+  end
+end


### PR DESCRIPTION
$## Summary
- group profile contribution cards by repository instead of repository owner
- link each card directly to the matching repository PR search
- add a regression test covering multiple repos under the same org

## Why
Issue #168 reports inflated/misaligned contribution counts and missing repos on developer profiles. The profile UI was collapsing multiple repositories owned by the same org into a single card, then showing one repo link with aggregated counts from all repos in that org.

Fixes #168