### PR TITLE
Clarify GitHub authorization copy

### DIFF
--- a/lib/algora_web/live/sign_in_live.ex
+++ b/lib/algora_web/live/sign_in_live.ex
@@ -128,6 +128,11 @@ defmodule AlgoraWeb.SignInLive do
               <.button :if={!@secret} href={@authorize_url} class="w-full py-5">
                 <Logos.github class="size-5 mr-2 -ml-1 shrink-0" /> Continue with GitHub
               </.button>
+              <p :if={!@secret} class="mt-3 text-xs/5 text-muted-foreground">
+                GitHub calls this authorization "act on your behalf." Algora uses it to identify
+                your GitHub account and perform actions you request, like claiming bounties.
+                Repository access is granted separately when you install the GitHub App.
+              </p>
             </div>
 
             <.simple_form

--- a/test/algora_web/live/sign_in_live_test.exs
+++ b/test/algora_web/live/sign_in_live_test.exs
@@ -1,0 +1,13 @@
+defmodule AlgoraWeb.SignInLiveTest do
+  use AlgoraWeb.ConnCase, async: true
+
+  import Phoenix.LiveViewTest
+
+  test "explains GitHub authorization wording on login", %{conn: conn} do
+    {:ok, _view, html} = live(conn, ~p"/auth/login")
+
+    assert html =~ "GitHub calls this authorization"
+    assert html =~ "act on your behalf"
+    assert html =~ "Repository access is granted separately"
+  end
+end


### PR DESCRIPTION
Fixes #169.

## Summary
- explain GitHub’s “act on your behalf” wording under the developer GitHub sign-in button
- clarify that Algora uses GitHub authorization for identity/requested actions, while repository access is granted through GitHub App installation
- add a LiveView regression test for the login page copy

## Validation
- `TEST_DATABASE_URL=postgresql://postgres:postgres@localhost:15432/algora_test mix test test/algora_web/live/sign_in_live_test.exs` (`1 test, 0 failures`)
- `mix format --check-formatted lib/algora_web/live/sign_in_live.ex test/algora_web/live/sign_in_live_test.exs`
- `git diff HEAD~1..HEAD --check`
- `git diff HEAD~1..HEAD | gitleaks detect --pipe --no-banner --redact` (`no leaks found`)