### PR TITLE
Refresh mirrored handle on GitHub re-login

### DIFF
--- a/lib/algora/accounts/schemas/user.ex
+++ b/lib/algora/accounts/schemas/user.ex
@@ -310,7 +310,7 @@ defmodule Algora.Accounts.User do
     if identity_changeset.valid? do
       params =
         %{
-          "handle" => user.handle || Algora.Organizations.ensure_unique_handle(info["login"]),
+          "handle" => refreshed_handle(user, info["login"]),
           "email" => user.email || primary_email,
           "display_name" => user.display_name || info["name"],
           "bio" => user.bio || info["bio"],
@@ -321,7 +321,8 @@ defmodule Algora.Accounts.User do
           "provider" => "github",
           "provider_id" => to_string(info["id"]),
           "provider_login" => info["login"],
-          "provider_meta" => info
+          "provider_meta" => info,
+          "last_context" => refreshed_last_context(user, info["login"])
         }
 
       params =
@@ -344,7 +345,8 @@ defmodule Algora.Accounts.User do
         :provider,
         :provider_id,
         :provider_login,
-        :provider_meta
+        :provider_meta,
+        :last_context
       ])
       |> generate_id()
       |> validate_required([:email, :handle])
@@ -430,6 +432,21 @@ defmodule Algora.Accounts.User do
   def signup_changeset(%User{} = user, params) do
     cast(user, params, [:email, :signup_token])
   end
+
+  defp refreshed_handle(%User{handle: nil}, new_login), do: Algora.Organizations.ensure_unique_handle(new_login)
+
+  defp refreshed_handle(%User{handle: handle, provider_login: old_login}, new_login)
+       when is_binary(handle) and handle == old_login and is_binary(old_login) and old_login != new_login do
+    Algora.Organizations.ensure_unique_handle(new_login)
+  end
+
+  defp refreshed_handle(%User{handle: handle}, _new_login), do: handle
+
+  defp refreshed_last_context(%User{last_context: last_context, provider_login: old_login}, new_login)
+       when is_binary(last_context) and last_context == old_login and is_binary(old_login) and old_login != new_login,
+       do: new_login
+
+  defp refreshed_last_context(%User{last_context: last_context}, _new_login), do: last_context
 
   def validate_email(changeset) do
     changeset

--- a/test/algora/accounts_test.exs
+++ b/test/algora/accounts_test.exs
@@ -153,6 +153,66 @@ defmodule Algora.AccountsTest do
       assert user.id == user_again.id
     end
 
+    test "refreshes mirrored handle and last_context when github login changes", %{
+      emails: emails,
+      token: token,
+      primary_email: primary_email
+    } do
+      existing_user =
+        insert!(:user,
+          email: primary_email,
+          handle: "shravan20",
+          provider: "github",
+          provider_id: "12345",
+          provider_login: "shravan20",
+          last_context: "shravan20"
+        )
+
+      github_info = %{
+        "id" => "12345",
+        "login" => "zhravan",
+        "name" => "Shravan",
+        "avatar_url" => "https://example.com/avatar.jpg",
+        "bio" => "Updated bio"
+      }
+
+      {:ok, updated_user} = Accounts.register_github_user(existing_user, primary_email, github_info, emails, token)
+
+      assert updated_user.handle == "zhravan"
+      assert updated_user.provider_login == "zhravan"
+      assert updated_user.last_context == "zhravan"
+    end
+
+    test "preserves custom handle when github login changes", %{
+      emails: emails,
+      token: token,
+      primary_email: primary_email
+    } do
+      existing_user =
+        insert!(:user,
+          email: primary_email,
+          handle: "custom-handle",
+          provider: "github",
+          provider_id: "12345",
+          provider_login: "shravan20",
+          last_context: "custom-handle"
+        )
+
+      github_info = %{
+        "id" => "12345",
+        "login" => "zhravan",
+        "name" => "Shravan",
+        "avatar_url" => "https://example.com/avatar.jpg",
+        "bio" => "Updated bio"
+      }
+
+      {:ok, updated_user} = Accounts.register_github_user(existing_user, primary_email, github_info, emails, token)
+
+      assert updated_user.handle == "custom-handle"
+      assert updated_user.provider_login == "zhravan"
+      assert updated_user.last_context == "custom-handle"
+    end
+
     test "user.name is never nil", %{
       github_info: github_info,
       emails: emails,


### PR DESCRIPTION
## Summary
- refresh a user's handle when a GitHub re-login changes `provider_login` and the stored handle still mirrors the old login
- refresh `last_context` in the same mirrored-login case so post-login redirects stop pointing at the stale dashboard path
- add regression tests for both the renamed-login case and custom-handle preservation

## Testing
- TEST_DATABASE_URL="ecto://postgres:postgres@localhost:15432/algora_test" mix test test/algora/accounts_test.exs

Fixes #183