### PR TITLE
fix: handle stale login redirect contexts (#183)

### DIFF
--- a/lib/algora_web/controllers/user_auth.ex
+++ b/lib/algora_web/controllers/user_auth.ex
@@ -241,7 +241,25 @@ defmodule AlgoraWeb.UserAuth do
   def signed_in_path_from_context(org_handle), do: ~p"/#{org_handle}/dashboard"
 
   def signed_in_path(%User{} = user) do
-    signed_in_path_from_context(Accounts.last_context(user))
+    case Accounts.last_context(user) do
+      "personal" ->
+        signed_in_path_from_context("personal")
+
+      "preview/" <> _ = preview_context ->
+        signed_in_path_from_context(preview_context)
+
+      context ->
+        case Accounts.get_user_by_handle(context) do
+          %User{type: :organization, handle: handle} ->
+            signed_in_path_from_context(handle)
+
+          %User{type: :individual} ->
+            signed_in_path_from_context("personal")
+
+          nil ->
+            signed_in_path_from_context(Accounts.default_context())
+        end
+    end
   end
 
   def signed_in_path(conn) do

--- a/test/algora_web/controllers/user_auth_test.exs
+++ b/test/algora_web/controllers/user_auth_test.exs
@@ -1,6 +1,8 @@
 defmodule AlgoraWeb.UserAuthTest do
   use AlgoraWeb.ConnCase
 
+  import Algora.Factory
+
   alias AlgoraWeb.UserAuth
 
   describe "verify_login_code/2" do
@@ -141,6 +143,21 @@ defmodule AlgoraWeb.UserAuthTest do
 
       assert {:ok, result} = UserAuth.verify_preview_code(padded_code, id)
       assert result == id
+    end
+  end
+
+  describe "signed_in_path/1" do
+    test "falls back to /home when last_context points to a missing handle" do
+      user = insert!(:user, handle: "zhravan", last_context: "shravan20")
+
+      assert UserAuth.signed_in_path(user) == "/home"
+    end
+
+    test "routes org contexts to the org dashboard" do
+      org = insert!(:organization, handle: "acme")
+      user = insert!(:user, last_context: org.handle)
+
+      assert UserAuth.signed_in_path(user) == "/acme/dashboard"
     end
   end
 end


### PR DESCRIPTION
$## Summary
- validate the saved `last_context` before using it as a signed-in redirect target
- keep valid org contexts going to `/{org}/dashboard`
- fall back to `/home` when the saved handle is stale or points at an individual user
- add controller tests covering stale-handle and org-context redirects

## Why
Issue #183 reports users getting redirected to an old GitHub handle after renaming their account, which leads to a 404 after login. The redirect logic trusted `last_context` blindly and treated any handle as an org dashboard target.

Fixes #183