### PR TITLE
fix: remove profile subdomain alert side channel (#201)

### DIFF
--- a/lib/algora_web/endpoint.ex
+++ b/lib/algora_web/endpoint.ex
@@ -124,7 +124,6 @@ defmodule AlgoraWeb.Endpoint do
         conn.request_path
 
       _user ->
-        Algora.Activities.alert("👀 Someone is viewing https://#{sub}.algora.io", :critical)
         Path.join(["/#{sub}/candidates", conn.request_path])
     end
   end

--- a/test/algora_web/controllers/endpoint_subdomain_test.exs
+++ b/test/algora_web/controllers/endpoint_subdomain_test.exs
@@ -1,0 +1,17 @@
+defmodule AlgoraWeb.EndpointSubdomainTest do
+  use AlgoraWeb.ConnCase, async: true
+
+  import Algora.Factory
+
+  test "known profile subdomains redirect without creating a critical activity", %{conn: conn} do
+    insert!(:user, handle: "acme")
+
+    conn =
+      conn
+      |> Map.put(:host, "acme.algora.io")
+      |> get("/jobs")
+
+    assert redirected_to(conn, 301) == "http://localhost/acme/candidates/jobs"
+    assert_activity_names([])
+  end
+end


### PR DESCRIPTION
$## Summary
- stop emitting a critical activity alert when a request hits a valid profile subdomain
- keep the existing subdomain redirect behavior intact
- add a regression test proving known subdomains still redirect without creating activities

## Why
Issue #201 points out that `canonical_host/2` performed a handle lookup and emitted a critical alert only when the subdomain matched a real user handle. That creates an internal side channel for username/subdomain enumeration.

Fixes #201