### PR TITLE
Respect customized contribution status

### DIFF
--- a/lib/algora/workspace/workspace.ex
+++ b/lib/algora/workspace/workspace.ex
@@ -893,10 +893,14 @@ defmodule Algora.Workspace do
                  ilike(repo_owner.provider_login, "%firstcontributions%") or
                  repo_owner.provider_login == "up-for-grabs"),
         order_by: [
+          desc: fragment("CASE WHEN ? = 'highlighted' THEN 1 ELSE 0 END", uc.status),
           desc: fragment("CASE WHEN ? && ?::citext[] THEN 1 ELSE 0 END", r.tech_stack, ^tech_stack),
           desc: r.stargazers_count
         ],
         select: %UserContribution{
+          id: uc.id,
+          user_id: uc.user_id,
+          repository_id: uc.repository_id,
           contribution_count: uc.contribution_count,
           user: map(u, [:id, :provider_login]),
           status: uc.status,
@@ -921,6 +925,13 @@ defmodule Algora.Workspace do
         where(query, [uc, u, r, repo_owner], repo_owner.type == :organization)
       else
         query
+      end
+
+    query =
+      if opts[:include_hidden] do
+        query
+      else
+        where(query, [uc, u, r, repo_owner], uc.status != :hidden)
       end
 
     query =

--- a/test/algora/workspace_test.exs
+++ b/test/algora/workspace_test.exs
@@ -1,0 +1,73 @@
+defmodule Algora.WorkspaceTest do
+  use Algora.DataCase
+
+  alias Algora.Workspace
+
+  describe "list_user_contributions/2" do
+    test "prioritizes highlighted contributions before higher-star default contributions" do
+      user = insert!(:user)
+      default_owner = insert!(:organization, provider_login: "default-owner", stargazers_count: 10_000)
+      highlighted_owner = insert!(:organization, provider_login: "highlighted-owner", stargazers_count: 100)
+
+      default_repo =
+        insert!(:repository,
+          user: default_owner,
+          name: "large-star-project",
+          stargazers_count: 10_000,
+          tech_stack: ["Rust"]
+        )
+
+      highlighted_repo =
+        insert!(:repository,
+          user: highlighted_owner,
+          name: "domain-project",
+          stargazers_count: 100,
+          tech_stack: ["Rust"]
+        )
+
+      insert!(:user_contribution, user: user, repository: default_repo, contribution_count: 1)
+
+      insert!(:user_contribution,
+        user: user,
+        repository: highlighted_repo,
+        contribution_count: 5,
+        status: :highlighted
+      )
+
+      contributions = Workspace.list_user_contributions([user.id], display_all: true)
+
+      assert Enum.map(contributions, & &1.repository.name) == ["domain-project", "large-star-project"]
+    end
+
+    test "hides hidden contributions unless requested" do
+      user = insert!(:user)
+      visible_owner = insert!(:organization, provider_login: "visible-owner")
+      hidden_owner = insert!(:organization, provider_login: "hidden-owner")
+
+      visible_repo =
+        insert!(:repository,
+          user: visible_owner,
+          name: "visible-project",
+          stargazers_count: 50,
+          tech_stack: ["Elixir"]
+        )
+
+      hidden_repo =
+        insert!(:repository,
+          user: hidden_owner,
+          name: "hidden-project",
+          stargazers_count: 50_000,
+          tech_stack: ["Elixir"]
+        )
+
+      insert!(:user_contribution, user: user, repository: visible_repo)
+      insert!(:user_contribution, user: user, repository: hidden_repo, status: :hidden)
+
+      visible_contributions = Workspace.list_user_contributions([user.id], display_all: true)
+      all_contributions = Workspace.list_user_contributions([user.id], display_all: true, include_hidden: true)
+
+      assert Enum.map(visible_contributions, & &1.repository.name) == ["visible-project"]
+      assert Enum.map(all_contributions, & &1.repository.name) == ["hidden-project", "visible-project"]
+    end
+  end
+end

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -222,6 +222,14 @@ defmodule Algora.Factory do
     }
   end
 
+  def user_contribution_factory do
+    %Algora.Workspace.UserContribution{
+      id: Nanoid.generate(),
+      contribution_count: 1,
+      last_fetched_at: DateTime.utc_now()
+    }
+  end
+
   def ticket_factory do
     %Algora.Workspace.Ticket{
       id: Nanoid.generate(),


### PR DESCRIPTION
Refs #208.

## Summary
- sort highlighted contribution records before star-based defaults in profile contribution lists
- hide contributions marked hidden by default while keeping an explicit include option for management flows
- add Workspace coverage for highlighted and hidden contribution status behavior

This does not add the profile UI for users to edit contribution status.

## Validation
- `mix format --check-formatted lib/algora/workspace/workspace.ex test/support/factory.ex test/algora/workspace_test.exs`
- `TEST_DATABASE_URL=postgresql://postgres:postgres@localhost:15432/algora_test mix test test/algora/workspace_test.exs` (`2 tests, 0 failures`; existing unrelated Oban/ChromicPDF warnings were emitted after the test run)
- `git diff HEAD~1..HEAD --check`
- `git diff HEAD~1..HEAD | gitleaks detect --pipe --no-banner --redact` (`no leaks found`)
