### PR TITLE
Add local bounty tracking buckets to /bounties

### DIFF
--- a/assets/js/app.ts
+++ b/assets/js/app.ts
@@ -934,6 +934,105 @@ const Hooks = {
       this.storage.removeItem(obj.key);
     },
   },
+  BountyBuckets: {
+    mounted() {
+      this.storageKey =
+        this.el.getAttribute("data-storage-key") || "algora:bounty-preferences:v1";
+      this.handleClick = (event: Event) => {
+        const target = event.target as HTMLElement | null;
+        const button = target?.closest("[data-bounty-action]") as HTMLElement | null;
+        if (!button) return;
+
+        event.preventDefault();
+        const item = button.closest("[data-bounty-id]") as HTMLElement | null;
+        if (!item) return;
+
+        const bountyId = item.dataset.bountyId;
+        const action = button.dataset.bountyAction;
+        if (!bountyId || !action) return;
+
+        const preferences = this.readPreferences();
+        const current = preferences[bountyId] || "remaining";
+
+        if (action === "favorite") {
+          preferences[bountyId] = current === "favorite" ? "remaining" : "favorite";
+        }
+
+        if (action === "ignore") {
+          preferences[bountyId] = current === "ignored" ? "remaining" : "ignored";
+        }
+
+        if (preferences[bountyId] === "remaining") {
+          delete preferences[bountyId];
+        }
+
+        this.writePreferences(preferences);
+        this.applyBuckets();
+      };
+
+      this.el.addEventListener("click", this.handleClick);
+      this.applyBuckets();
+    },
+
+    updated() {
+      this.applyBuckets();
+    },
+
+    destroyed() {
+      this.el.removeEventListener("click", this.handleClick);
+    },
+
+    readPreferences() {
+      try {
+        return JSON.parse(localStorage.getItem(this.storageKey) || "{}");
+      } catch {
+        return {};
+      }
+    },
+
+    writePreferences(preferences: Record<string, string>) {
+      localStorage.setItem(this.storageKey, JSON.stringify(preferences));
+    },
+
+    applyBuckets() {
+      const preferences = this.readPreferences();
+      const lists = {
+        favorite: this.el.querySelector('[data-bucket-list="favorite"]'),
+        remaining: this.el.querySelector('[data-bucket-list="remaining"]'),
+        ignored: this.el.querySelector('[data-bucket-list="ignored"]'),
+      } as Record<string, HTMLElement | null>;
+
+      const items = Array.from(
+        this.el.querySelectorAll("[data-bounty-id]"),
+      ) as HTMLElement[];
+
+      items.forEach((item) => {
+        const bountyId = item.dataset.bountyId;
+        const bucket = bountyId ? preferences[bountyId] || "remaining" : "remaining";
+        lists[bucket]?.appendChild(item);
+        this.updateLabels(item, bucket);
+      });
+
+      ["favorite", "ignored"].forEach((bucket) => {
+        const section = this.el.querySelector(`[data-bucket="${bucket}"]`);
+        const count = lists[bucket]?.children.length || 0;
+        section?.classList.toggle("hidden", count === 0);
+      });
+    },
+
+    updateLabels(item: HTMLElement, bucket: string) {
+      const favoriteLabel = item.querySelector("[data-favorite-label]");
+      const ignoreLabel = item.querySelector("[data-ignore-label]");
+
+      if (favoriteLabel) {
+        favoriteLabel.textContent = bucket === "favorite" ? "Unfavorite" : "Favorite";
+      }
+
+      if (ignoreLabel) {
+        ignoreLabel.textContent = bucket === "ignored" ? "Unignore" : "Ignore";
+      }
+    },
+  },
   CtrlEnterSubmit: {
     mounted() {
       this.el.addEventListener("keydown", (e) => {

--- a/lib/algora_web/components/bounties.ex
+++ b/lib/algora_web/components/bounties.ex
@@ -9,38 +9,90 @@ defmodule AlgoraWeb.Components.Bounties do
 
   def bounties(assigns) do
     ~H"""
-    <div class="relative -mx-2 -mt-2 overflow-auto scrollbar-thin">
-      <ul class="divide-y divide-border">
-        <%= for bounty <- @bounties do %>
-          <.link href={Bounty.url(bounty)} class="block whitespace-nowrap hover:bg-muted/50">
-            <li class="flex items-center py-2 px-3">
-              <div class="flex-shrink-0 mr-3">
-                <.avatar class="h-8 w-8">
-                  <.avatar_image src={bounty.repository.owner.avatar_url || bounty.owner.avatar_url} />
-                  <.avatar_fallback>
-                    {Algora.Util.initials(User.handle(bounty.repository.owner || bounty.owner))}
-                  </.avatar_fallback>
-                </.avatar>
-              </div>
+    <div
+      id="bounty-buckets"
+      phx-hook="BountyBuckets"
+      data-storage-key="algora:bounty-preferences:v1"
+      class="space-y-6"
+    >
+      <section data-bucket="favorite" class="hidden space-y-2">
+        <div class="flex items-center gap-2 px-1">
+          <.icon name="tabler-star-filled" class="h-4 w-4 text-amber-400" />
+          <h3 class="text-sm font-semibold text-foreground">Favorites</h3>
+        </div>
+        <div class="relative -mx-2 overflow-auto scrollbar-thin">
+          <ul data-bucket-list="favorite" class="divide-y divide-border rounded-lg border border-border/60">
+          </ul>
+        </div>
+      </section>
 
-              <div class="flex-grow min-w-0 mr-4">
-                <div class="flex items-center text-sm">
-                  <span class="font-semibold mr-1">
-                    {bounty.repository.owner.name || bounty.owner.name}
-                  </span>
-                  <span :if={bounty.ticket.number} class="text-muted-foreground mr-2">
-                    #{bounty.ticket.number}
-                  </span>
-                  <span class="font-display whitespace-nowrap text-sm font-semibold tabular-nums text-success mr-2">
-                    {Money.to_string!(bounty.amount)}
-                  </span>
-                  <span class="text-foreground">{bounty.ticket.title}</span>
+      <section data-bucket="remaining" class="space-y-2">
+        <div class="flex items-center gap-2 px-1">
+          <.icon name="tabler-list" class="h-4 w-4 text-muted-foreground" />
+          <h3 class="text-sm font-semibold text-foreground">Remaining</h3>
+        </div>
+        <div class="relative -mx-2 overflow-auto scrollbar-thin">
+          <ul data-bucket-list="remaining" class="divide-y divide-border rounded-lg border border-border/60">
+            <%= for bounty <- @bounties do %>
+              <li data-bounty-id={bounty.id} class="flex items-center gap-3 px-3 py-2 hover:bg-muted/50">
+                <div class="flex-shrink-0">
+                  <.avatar class="h-8 w-8">
+                    <.avatar_image src={bounty.repository.owner.avatar_url || bounty.owner.avatar_url} />
+                    <.avatar_fallback>
+                      {Algora.Util.initials(User.handle(bounty.repository.owner || bounty.owner))}
+                    </.avatar_fallback>
+                  </.avatar>
                 </div>
-              </div>
-            </li>
-          </.link>
-        <% end %>
-      </ul>
+
+                <.link href={Bounty.url(bounty)} class="min-w-0 flex-1">
+                  <div class="flex items-center text-sm min-w-0">
+                    <span class="font-semibold mr-1 truncate">
+                      {bounty.repository.owner.name || bounty.owner.name}
+                    </span>
+                    <span :if={bounty.ticket.number} class="text-muted-foreground mr-2 shrink-0">
+                      #{bounty.ticket.number}
+                    </span>
+                    <span class="font-display whitespace-nowrap text-sm font-semibold tabular-nums text-success mr-2 shrink-0">
+                      {Money.to_string!(bounty.amount)}
+                    </span>
+                    <span class="text-foreground truncate">{bounty.ticket.title}</span>
+                  </div>
+                </.link>
+
+                <div class="flex shrink-0 items-center gap-2">
+                  <button
+                    type="button"
+                    data-bounty-action="favorite"
+                    class="inline-flex items-center rounded-md border border-border px-2 py-1 text-xs font-medium text-muted-foreground transition hover:bg-accent hover:text-foreground"
+                    aria-label="Toggle favorite bounty"
+                  >
+                    <span data-favorite-label>Favorite</span>
+                  </button>
+                  <button
+                    type="button"
+                    data-bounty-action="ignore"
+                    class="inline-flex items-center rounded-md border border-border px-2 py-1 text-xs font-medium text-muted-foreground transition hover:bg-accent hover:text-foreground"
+                    aria-label="Toggle ignored bounty"
+                  >
+                    <span data-ignore-label>Ignore</span>
+                  </button>
+                </div>
+              </li>
+            <% end %>
+          </ul>
+        </div>
+      </section>
+
+      <section data-bucket="ignored" class="hidden space-y-2">
+        <div class="flex items-center gap-2 px-1">
+          <.icon name="tabler-eye-off" class="h-4 w-4 text-muted-foreground" />
+          <h3 class="text-sm font-semibold text-foreground">Ignored</h3>
+        </div>
+        <div class="relative -mx-2 overflow-auto scrollbar-thin">
+          <ul data-bucket-list="ignored" class="divide-y divide-border rounded-lg border border-border/60">
+          </ul>
+        </div>
+      </section>
     </div>
     """
   end


### PR DESCRIPTION
## Summary
- add client-side Favorite and Ignore controls for bounty rows on /bounties
- persist bucket state in localStorage and rebucket rows into Favorites, Remaining, and Ignored sections
- keep the first pass fully local with no server-side persistence or schema changes

## Validation
- mix compile
- npm install
- node build.js

Closes #162