### PR TITLE
Show bounty activity signals

### DIFF
--- a/lib/algora/bounties/bounties.ex
+++ b/lib/algora/bounties/bounties.ex
@@ -1331,9 +1331,34 @@ defmodule Algora.Bounties do
     |> join(:inner, [b], o in assoc(b, :owner), as: :o)
     |> join(:left, [t: t], r in assoc(t, :repository), as: :r)
     |> join(:left, [r: r], ro in assoc(r, :user), as: :ro)
+    |> join(:left, [t: t], a in subquery(attempt_activity_query()), on: a.ticket_id == t.id, as: :attempt_activity)
+    |> join(:left, [t: t], c in subquery(claim_activity_query()), on: c.ticket_id == t.id, as: :claim_activity)
     |> where([b], not is_nil(b.amount))
     |> where([b], b.status != :cancelled)
     |> apply_criteria(criteria)
+  end
+
+  defp attempt_activity_query do
+    from a in Attempt,
+      where: a.status == :active,
+      group_by: a.ticket_id,
+      select: %{
+        ticket_id: a.ticket_id,
+        active_attempt_count: count(a.id),
+        last_attempt_at: max(a.inserted_at)
+      }
+  end
+
+  defp claim_activity_query do
+    from c in Claim,
+      where: c.status != :cancelled,
+      where: c.type == :pull_request,
+      group_by: c.target_id,
+      select: %{
+        ticket_id: c.target_id,
+        pull_request_count: count(c.group_id, :distinct),
+        last_claim_at: max(c.inserted_at)
+      }
   end
 
   def list_bounties_with(base_query, criteria \\ []) do
@@ -1341,7 +1366,7 @@ defmodule Algora.Bounties do
     |> list_bounties_query(criteria)
     # TODO: sort by b.paid_at if criteria[:status] == :paid
     |> order_by([b], desc: b.inserted_at, desc: b.id)
-    |> select([b, o: o, t: t, ro: ro, r: r], %{
+    |> select([b, o: o, t: t, ro: ro, r: r, attempt_activity: a, claim_activity: c], %{
       id: b.id,
       inserted_at: b.inserted_at,
       amount: b.amount,
@@ -1373,6 +1398,19 @@ defmodule Algora.Bounties do
           provider_login: ro.provider_login,
           avatar_url: ro.avatar_url
         }
+      },
+      activity: %{
+        active_attempt_count: type(fragment("COALESCE(?, 0)", a.active_attempt_count), :integer),
+        pull_request_count: type(fragment("COALESCE(?, 0)", c.pull_request_count), :integer),
+        last_activity_at:
+          fragment(
+            "GREATEST(?, COALESCE(?, ?), COALESCE(?, ?))",
+            b.inserted_at,
+            a.last_attempt_at,
+            b.inserted_at,
+            c.last_claim_at,
+            b.inserted_at
+          )
       }
     })
     |> Repo.all()

--- a/lib/algora_web/components/bounties.ex
+++ b/lib/algora_web/components/bounties.ex
@@ -12,6 +12,7 @@ defmodule AlgoraWeb.Components.Bounties do
     <div class="relative -mx-2 -mt-2 overflow-auto scrollbar-thin">
       <ul class="divide-y divide-border">
         <%= for bounty <- @bounties do %>
+          <% activity = bounty_activity(bounty) %>
           <.link href={Bounty.url(bounty)} class="block whitespace-nowrap hover:bg-muted/50">
             <li class="flex items-center py-2 px-3">
               <div class="flex-shrink-0 mr-3">
@@ -34,7 +35,28 @@ defmodule AlgoraWeb.Components.Bounties do
                   <span class="font-display whitespace-nowrap text-sm font-semibold tabular-nums text-success mr-2">
                     {Money.to_string!(bounty.amount)}
                   </span>
+                  <span
+                    :if={active_bounty?(activity)}
+                    class="mr-2 rounded-full bg-success/10 px-2 py-0.5 text-xs font-medium text-success"
+                  >
+                    Active
+                  </span>
                   <span class="text-foreground">{bounty.ticket.title}</span>
+                </div>
+
+                <div class="mt-1 flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-muted-foreground">
+                  <span :if={activity.active_attempt_count > 0} class="inline-flex items-center gap-1">
+                    <.icon name="tabler-users" class="size-3.5" />
+                    {activity.active_attempt_count} active
+                  </span>
+                  <span :if={activity.pull_request_count > 0} class="inline-flex items-center gap-1">
+                    <.icon name="tabler-git-pull-request" class="size-3.5" />
+                    {activity.pull_request_count} {pr_label(activity.pull_request_count)}
+                  </span>
+                  <span :if={activity.last_activity_at} class="inline-flex items-center gap-1">
+                    <.icon name="tabler-clock" class="size-3.5" />
+                    {Algora.Util.relative_time(activity.last_activity_at)}
+                  </span>
                 </div>
               </div>
             </li>
@@ -44,4 +66,27 @@ defmodule AlgoraWeb.Components.Bounties do
     </div>
     """
   end
+
+  defp bounty_activity(%{activity: activity}) when is_map(activity) do
+    %{
+      active_attempt_count: Map.get(activity, :active_attempt_count, 0),
+      pull_request_count: Map.get(activity, :pull_request_count, 0),
+      last_activity_at: Map.get(activity, :last_activity_at)
+    }
+  end
+
+  defp bounty_activity(bounty) do
+    %{
+      active_attempt_count: 0,
+      pull_request_count: 0,
+      last_activity_at: Map.get(bounty, :inserted_at)
+    }
+  end
+
+  defp active_bounty?(%{active_attempt_count: attempts, pull_request_count: prs}) do
+    attempts > 0 or prs > 0
+  end
+
+  defp pr_label(1), do: "PR"
+  defp pr_label(_count), do: "PRs"
 end

--- a/test/algora/bounties_test.exs
+++ b/test/algora/bounties_test.exs
@@ -658,6 +658,74 @@ defmodule Algora.BountiesTest do
       assert Enum.any?(bounties, &(&1.status == :paid))
       refute Enum.any?(bounties, &(&1.status == :cancelled))
     end
+
+    test "includes active attempt and pull request activity", %{ticket: ticket} do
+      bounty =
+        insert!(:bounty,
+          status: :open,
+          ticket: ticket,
+          owner: insert!(:user),
+          inserted_at: ~U[2024-01-01 12:00:00Z]
+        )
+
+      insert!(:attempt,
+        ticket: ticket,
+        user: insert!(:user),
+        status: :active,
+        inserted_at: ~U[2024-01-02 12:00:00Z]
+      )
+
+      insert!(:attempt,
+        ticket: ticket,
+        user: insert!(:user),
+        status: :inactive,
+        inserted_at: ~U[2024-01-03 12:00:00Z]
+      )
+
+      pull_request = insert!(:ticket, type: :pull_request, number: 101, repository: ticket.repository)
+
+      insert!(:claim,
+        target: ticket,
+        source: pull_request,
+        user: insert!(:user),
+        status: :pending,
+        group_id: "group-101",
+        inserted_at: ~U[2024-01-04 12:00:00Z]
+      )
+
+      insert!(:claim,
+        target: ticket,
+        source: pull_request,
+        user: insert!(:user),
+        status: :pending,
+        group_id: "group-101",
+        inserted_at: ~U[2024-01-05 12:00:00Z]
+      )
+
+      insert!(:claim,
+        target: ticket,
+        source: insert!(:ticket, type: :pull_request, number: 102, repository: ticket.repository),
+        user: insert!(:user),
+        status: :cancelled,
+        group_id: "group-102",
+        inserted_at: ~U[2024-01-06 12:00:00Z]
+      )
+
+      insert!(:claim,
+        target: ticket,
+        user: insert!(:user),
+        type: :review,
+        status: :pending,
+        group_id: "group-review",
+        inserted_at: ~U[2024-01-07 12:00:00Z]
+      )
+
+      [listed_bounty] = Bounties.list_bounties(id: bounty.id)
+
+      assert listed_bounty.activity.active_attempt_count == 1
+      assert listed_bounty.activity.pull_request_count == 1
+      assert NaiveDateTime.truncate(listed_bounty.activity.last_activity_at, :second) == ~N[2024-01-05 12:00:00]
+    end
   end
 
   describe "list_claims/1" do


### PR DESCRIPTION
Refs #224.

## Summary
- add active attempt, pull-request claim, and last-activity metadata to listed bounties
- render compact activity signals on bounty rows
- cover active/inactive attempts, duplicate claim grouping, cancelled claims, and non-PR claim exclusion

## Validation
- `mix format --check-formatted lib/algora/bounties/bounties.ex lib/algora_web/components/bounties.ex test/algora/bounties_test.exs`
- `TEST_DATABASE_URL=postgresql://postgres:postgres@localhost:15432/algora_test mix test test/algora/bounties_test.exs` (20 tests, 0 failures; unrelated local Oban sandbox warnings emitted around test lifecycle)
- `git diff HEAD~1..HEAD --check`
- `git diff HEAD~1..HEAD | gitleaks detect --pipe --no-banner --redact` (no leaks found)

## Notes
- This is a compact list-row signal slice, not the full realtime/trend/sorting request.
- I did not add a component render assertion or run production-like query-plan checks.