### PR TITLE
Refresh stale tech stacks during ticket sync

### DIFF
--- a/lib/algora/workspace/workspace.ex
+++ b/lib/algora/workspace/workspace.ex
@@ -108,7 +108,8 @@ defmodule Algora.Workspace do
 
   def create_ticket_from_github(token, owner, repo, number) do
     with {:ok, issue} <- Github.get_issue(token, owner, repo, number),
-         {:ok, repository} <- ensure_repository(token, owner, repo) do
+         {:ok, repository} <- ensure_repository(token, owner, repo, force: true),
+         {:ok, _tech_stack} <- ensure_repo_tech_stack(token, repository, force: true) do
       issue
       |> Ticket.github_changeset(repository)
       |> Repo.insert()
@@ -118,7 +119,8 @@ defmodule Algora.Workspace do
   def update_ticket_from_github(token, owner, repo, number) do
     with ticket when not is_nil(ticket) <- get_ticket(owner, repo, number),
          {:ok, issue} <- Github.get_issue(token, owner, repo, number),
-         {:ok, repository} <- ensure_repository(token, owner, repo) do
+         {:ok, repository} <- ensure_repository(token, owner, repo, force: true),
+         {:ok, _tech_stack} <- ensure_repo_tech_stack(token, repository, force: true) do
       ticket
       |> Ticket.github_changeset(issue, repository)
       |> Repo.update()
@@ -674,11 +676,17 @@ defmodule Algora.Workspace do
     end
   end
 
-  def ensure_repo_tech_stack(_token, %{tech_stack: tech_stack}) when tech_stack != [] do
-    {:ok, tech_stack}
+  def ensure_repo_tech_stack(token, repository, opts \\ []) do
+    force_refresh? = Keyword.get(opts || [], :force, false)
+
+    if repository.tech_stack != [] and not force_refresh? do
+      {:ok, repository.tech_stack}
+    else
+      refresh_repo_tech_stack(token, repository)
+    end
   end
 
-  def ensure_repo_tech_stack(token, repository) do
+  defp refresh_repo_tech_stack(token, repository) do
     with {:ok, languages} <- Github.list_repository_languages(token, repository.user.provider_login, repository.name) do
       top_languages =
         languages

--- a/test/algora/workspace_test.exs
+++ b/test/algora/workspace_test.exs
@@ -1,0 +1,36 @@
+defmodule Algora.WorkspaceTest do
+  use Algora.DataCase
+
+  alias Algora.Workspace
+
+  defmodule GithubClientStub do
+    def list_repository_languages(_token, "piedpiper", "middle-out"), do: {:ok, %{"Go" => 100, "Python" => 50}}
+    def list_repository_languages(_token, _owner, _repo), do: {:ok, %{}}
+  end
+
+  describe "ensure_repo_tech_stack/3" do
+    setup do
+      previous_client = Application.get_env(:algora, :github_client)
+      Application.put_env(:algora, :github_client, GithubClientStub)
+
+      on_exit(fn ->
+        Application.put_env(:algora, :github_client, previous_client)
+      end)
+
+      user = insert(:user, provider: "github", provider_login: "piedpiper", provider_id: "1")
+      repository = insert(:repository, user: user, tech_stack: ["Java"], name: "middle-out")
+
+      %{repository: Repo.preload(repository, :user)}
+    end
+
+    test "returns cached tech stack by default", %{repository: repository} do
+      assert {:ok, ["Java"]} = Workspace.ensure_repo_tech_stack("token", repository)
+      assert Repo.get!(Algora.Workspace.Repository, repository.id).tech_stack == ["Java"]
+    end
+
+    test "refreshes persisted tech stack when forced", %{repository: repository} do
+      assert {:ok, ["Go", "Python"]} = Workspace.ensure_repo_tech_stack("token", repository, force: true)
+      assert Repo.get!(Algora.Workspace.Repository, repository.id).tech_stack == ["Go", "Python"]
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- allow repository tech stacks to be force-refreshed when syncing tickets from GitHub
- refresh cached repository language data during ticket create/update flows so stale classifications do not persist forever
- add a regression test covering default cache reuse and forced refresh behavior

## Testing
- `TEST_DATABASE_URL='ecto://postgres:postgres@localhost:15432/algora_test' mix test test/algora/workspace_test.exs`

Closes #153.
