### PR TITLE
fix(bounties): hide Edit/Delete buttons from unauthorized users

### DIFF
--- a/lib/algora_web/live/org/bounties_live.ex
+++ b/lib/algora_web/live/org/bounties_live.ex
@@ -221,22 +221,24 @@ defmodule AlgoraWeb.Org.BountiesLive do
                     </td>
                     <td class="[&:has([role=checkbox])]:pr-0 p-4 align-middle">
                       <div class="flex items-center justify-end gap-2">
-                        <.button
-                          phx-click="edit-bounty-amount"
-                          phx-value-id={bounty.id}
-                          variant="secondary"
-                          size="sm"
-                        >
-                          Edit Amount
-                        </.button>
-                        <.button
-                          phx-click="delete-bounty"
-                          phx-value-id={bounty.id}
-                          variant="destructive"
-                          size="sm"
-                        >
-                          Delete
-                        </.button>
+                        <%= if @current_user_role in [:admin, :mod] do %>
+                          <.button
+                            phx-click="edit-bounty-amount"
+                            phx-value-id={bounty.id}
+                            variant="secondary"
+                            size="sm"
+                          >
+                            Edit Amount
+                          </.button>
+                          <.button
+                            phx-click="delete-bounty"
+                            phx-value-id={bounty.id}
+                            variant="destructive"
+                            size="sm"
+                          >
+                            Delete
+                          </.button>
+                        <% end %>
                       </div>
                     </td>
                   </tr>


### PR DESCRIPTION
The Edit Amount and Delete buttons on the org bounties page were rendered for all logged-in users regardless of role. Only admins and moderators should see these buttons, matching the existing backend authorization check (current_user_role in [:admin, :mod]).

Wraps both buttons in a frontend guard so non-owners never see actions they cannot perform, eliminating the confusing "You are not authorized" error on click.

Fixes #238