### PR TITLE
Hide bounty actions from unauthorized org viewers

### DIFF
--- a/lib/algora_web/live/org/bounties_live.ex
+++ b/lib/algora_web/live/org/bounties_live.ex
@@ -220,7 +220,7 @@ defmodule AlgoraWeb.Org.BountiesLive do
                       <% end %>
                     </td>
                     <td class="[&:has([role=checkbox])]:pr-0 p-4 align-middle">
-                      <div class="flex items-center justify-end gap-2">
+                      <div :if={@current_user_role in [:admin, :mod]} class="flex items-center justify-end gap-2">
                         <.button
                           phx-click="edit-bounty-amount"
                           phx-value-id={bounty.id}

--- a/test/algora_web/live/org/bounties_live_test.exs
+++ b/test/algora_web/live/org/bounties_live_test.exs
@@ -1,0 +1,39 @@
+defmodule AlgoraWeb.Org.BountiesLiveTest do
+  use AlgoraWeb.ConnCase, async: true
+
+  import Algora.Factory
+  import Phoenix.LiveViewTest
+
+  alias AlgoraWeb.UserAuth
+
+  setup %{conn: conn} do
+    conn = Phoenix.ConnTest.init_test_session(conn, %{})
+    org = insert!(:organization)
+    repo = insert!(:repository, user: org, name: "algora")
+    ticket = insert!(:ticket, repository: repo, number: 238, title: "Hide unauthorized bounty actions")
+    bounty = insert!(:bounty, owner: org, creator: org, ticket: ticket, amount: Money.new!(2500, :USD))
+
+    %{conn: conn, org: org, bounty: bounty}
+  end
+
+  test "hides bounty management actions from non-members", %{conn: conn, org: org} do
+    user = insert!(:user)
+    conn = UserAuth.put_current_user(conn, user)
+
+    assert {:ok, _view, html} = live(conn, "/#{org.handle}/bounties")
+    assert html =~ "Hide unauthorized bounty actions"
+    refute html =~ "Edit Amount"
+    refute html =~ "delete-bounty"
+  end
+
+  test "shows bounty management actions to org admins", %{conn: conn, org: org, bounty: bounty} do
+    admin = insert!(:user)
+    insert!(:member, user: admin, org: org, role: :admin)
+    conn = UserAuth.put_current_user(conn, admin)
+
+    assert {:ok, _view, html} = live(conn, "/#{org.handle}/bounties")
+    assert html =~ "Edit Amount"
+    assert html =~ ~s(phx-value-id="#{bounty.id}")
+    assert html =~ "delete-bounty"
+  end
+end


### PR DESCRIPTION
Fixes #238.

## What changed
- Hide the org bounty edit/delete action group unless the current viewer has an org `:admin` or `:mod` role.
- Keep the existing server-side authorization in place for `edit-bounty-amount` and `delete-bounty` events.
- Add LiveView coverage for non-member viewers and org admins on the org bounties page.

## Verification
- `git diff --check`
- Not run: `mix test test/algora_web/live/org/bounties_live_test.exs` because `mix` is not installed in this local environment.

## Notes
- Scoped to the EarnOps candidate issue.
