### PR TITLE
fix: hide bounty admin actions and stop subdomain handle oracle

### DIFF
--- a/lib/algora_web/endpoint.ex
+++ b/lib/algora_web/endpoint.ex
@@ -124,7 +124,6 @@ defmodule AlgoraWeb.Endpoint do
         conn.request_path
 
       _user ->
-        Algora.Activities.alert("👀 Someone is viewing https://#{sub}.algora.io", :critical)
         Path.join(["/#{sub}/candidates", conn.request_path])
     end
   end

--- a/lib/algora_web/live/org/bounties_live.ex
+++ b/lib/algora_web/live/org/bounties_live.ex
@@ -220,7 +220,10 @@ defmodule AlgoraWeb.Org.BountiesLive do
                       <% end %>
                     </td>
                     <td class="[&:has([role=checkbox])]:pr-0 p-4 align-middle">
-                      <div class="flex items-center justify-end gap-2">
+                      <div
+                        :if={@current_user_role in [:admin, :mod]}
+                        class="flex items-center justify-end gap-2"
+                      >
                         <.button
                           phx-click="edit-bounty-amount"
                           phx-value-id={bounty.id}


### PR DESCRIPTION
## Summary

- **#238** — Hide **Edit Amount** and **Delete** on org bounty rows unless the viewer is an org `:admin` or `:mod` (backend already blocked these; UI now matches).
- **#201** — Remove the critical Discord/email alert fired when `{handle}.algora.io` matches a real user handle, which let attackers enumerate valid handles via a side channel.

## Test plan

- [ ] Log in as a non-admin org member and confirm bounty admin buttons are hidden on `/{org}/bounties`.
- [ ] Log in as org admin/mod and confirm buttons still appear and work.
- [ ] Visit `{valid-handle}.algora.io` and confirm redirect still works without firing a critical alert.
- [ ] Visit `{invalid-handle}.algora.io` and confirm behavior is unchanged for unknown handles.

Closes #238
Closes #201