### PR TITLE
fix: hide unauthorized bounty actions on org bounties page

### DIFF
--- a/lib/algora_web/live/org/bounties_live.ex
+++ b/lib/algora_web/live/org/bounties_live.ex
@@ -220,7 +220,10 @@ defmodule AlgoraWeb.Org.BountiesLive do
                       <% end %>
                     </td>
                     <td class="[&:has([role=checkbox])]:pr-0 p-4 align-middle">
-                      <div class="flex items-center justify-end gap-2">
+                      <div
+                        :if={@current_user_role in [:admin, :mod]}
+                        class="flex items-center justify-end gap-2"
+                      >
                         <.button
                           phx-click="edit-bounty-amount"
                           phx-value-id={bounty.id}


### PR DESCRIPTION
## Summary

Fixes #238.

Hide `Edit Amount` and `Delete` actions on the org bounties page for users who are not authorized to manage bounties.

## Root Cause

The backend already rejects unauthorized `edit-bounty-amount` and `delete-bounty` events, but the buttons were still rendered for all logged-in users. That created a misleading UI path where users could click actions they were not allowed to perform.

## Changes

- render bounty action buttons only when `@current_user_role in [:admin, :mod]`
- leave existing server-side authorization checks in place

## Result

- unauthorized users no longer see admin/mod-only bounty actions
- admins and mods keep the existing edit/delete workflow
- UI behavior now matches backend permissions

## Verification

- confirmed the action cell is now role-gated in `Org.BountiesLive`
- backend authorization logic remains unchanged
- test suite was not run in this environment because Elixir/Mix is not installed here
