### PR TITLE
Fix OAuth redirect pending actions

### DIFF
--- a/lib/algora_web/live/crowdfund.ex
+++ b/lib/algora_web/live/crowdfund.ex
@@ -19,6 +19,7 @@ defmodule AlgoraWeb.CrowdfundLive do
   alias AlgoraWeb.Data.PlatformStats
   alias AlgoraWeb.Forms.BountyForm
   alias AlgoraWeb.Forms.TipForm
+  alias AlgoraWeb.LocalStore
 
   require Logger
 
@@ -58,7 +59,7 @@ defmodule AlgoraWeb.CrowdfundLive do
      |> assign(:page_title, "Crowdfund")
      |> assign(:page_image, "#{AlgoraWeb.Endpoint.url()}/og/crowdfund")
      |> assign(:screenshot?, not is_nil(params["screenshot"]))
-     |> assign(:oauth_url, Github.authorize_url(%{socket_id: socket.id}))
+     |> assign(:oauth_url, Github.authorize_url(%{return_to: "/crowdfund"}))
      |> assign(:featured_devs, Accounts.list_featured_developers())
      |> assign(:stats, stats)
      |> assign(:bounty_form, to_form(BountyForm.changeset(%BountyForm{}, %{})))
@@ -106,7 +107,7 @@ defmodule AlgoraWeb.CrowdfundLive do
   @impl true
   def render(assigns) do
     ~H"""
-    <div>
+    <div id="crowdfund-page" phx-hook="LocalStateStore">
       <%= if @screenshot? do %>
         <div class="-mt-24" />
       <% else %>
@@ -407,6 +408,28 @@ defmodule AlgoraWeb.CrowdfundLive do
   end
 
   @impl true
+  def handle_params(_params, _uri, socket) do
+    {:noreply,
+     socket
+     |> LocalStore.init(key: __MODULE__)
+     |> LocalStore.subscribe()}
+  end
+
+  @impl true
+  def handle_event("restore_settings", params, socket) do
+    socket = LocalStore.restore(socket, params)
+
+    case socket.assigns.pending_action do
+      nil ->
+        {:noreply, socket}
+
+      {event, params} ->
+        socket = LocalStore.assign_cached(socket, :pending_action, nil)
+        handle_event(event, params, socket)
+    end
+  end
+
+  @impl true
   def handle_event("create_bounty" = event, %{"bounty_form" => params} = unsigned_params, socket) do
     changeset =
       %BountyForm{}
@@ -436,8 +459,8 @@ defmodule AlgoraWeb.CrowdfundLive do
       else
         {:noreply,
          socket
-         |> assign(:pending_action, {event, unsigned_params})
-         |> push_event("open_popup", %{url: socket.assigns.oauth_url})}
+         |> LocalStore.assign_cached(:pending_action, {event, unsigned_params})
+         |> redirect(external: socket.assigns.oauth_url)}
       end
     else
       {:noreply, assign(socket, :bounty_form, to_form(changeset))}
@@ -473,8 +496,8 @@ defmodule AlgoraWeb.CrowdfundLive do
       else
         {:noreply,
          socket
-         |> assign(:pending_action, {event, unsigned_params})
-         |> push_event("open_popup", %{url: socket.assigns.oauth_url})}
+         |> LocalStore.assign_cached(:pending_action, {event, unsigned_params})
+         |> redirect(external: socket.assigns.oauth_url)}
       end
     else
       {:noreply, assign(socket, :tip_form, to_form(changeset))}

--- a/lib/algora_web/live/org/bounties_new_live.ex
+++ b/lib/algora_web/live/org/bounties_new_live.ex
@@ -11,6 +11,7 @@ defmodule AlgoraWeb.Org.BountiesNewLive do
   alias Algora.Github
   alias Algora.Payments
   alias AlgoraWeb.Forms.BountyForm
+  alias AlgoraWeb.LocalStore
 
   require Logger
 
@@ -51,7 +52,8 @@ defmodule AlgoraWeb.Org.BountiesNewLive do
       socket
       |> assign(:org, org)
       |> assign(:has_fresh_token?, Accounts.has_fresh_token?(socket.assigns.current_user))
-      |> assign(:oauth_url, Github.authorize_url(%{socket_id: socket.id}))
+      |> assign(:oauth_url, Github.authorize_url(%{return_to: "/#{org.handle}/bounties/new"}))
+      |> assign(:pending_action, nil)
       |> assign(:bounty_form, to_form(BountyForm.changeset(%BountyForm{}, %{})))
       |> assign(:page_title, org.name)
       |> assign(:page_description, "#{org.name} OSS bounty board - fund GitHub issues and prioritize development")
@@ -67,7 +69,11 @@ defmodule AlgoraWeb.Org.BountiesNewLive do
   @impl true
   def render(assigns) do
     ~H"""
-    <div class="container mx-auto max-w-7xl space-y-6 p-4 sm:px-6 lg:px-8">
+    <div
+      id="org-bounties-new-page"
+      class="container mx-auto max-w-7xl space-y-6 p-4 sm:px-6 lg:px-8"
+      phx-hook="LocalStateStore"
+    >
       <!-- Org Header -->
       <div class="rounded-xl border bg-card p-6 text-card-foreground">
         <div class="flex flex-col gap-6 md:flex-row">
@@ -266,6 +272,31 @@ defmodule AlgoraWeb.Org.BountiesNewLive do
   end
 
   @impl true
+  def handle_params(_params, uri, socket) do
+    return_to = URI.parse(uri).path
+
+    {:noreply,
+     socket
+     |> assign(:oauth_url, Github.authorize_url(%{return_to: return_to}))
+     |> LocalStore.init(key: __MODULE__)
+     |> LocalStore.subscribe()}
+  end
+
+  @impl true
+  def handle_event("restore_settings", params, socket) do
+    socket = LocalStore.restore(socket, params)
+
+    case socket.assigns.pending_action do
+      nil ->
+        {:noreply, socket}
+
+      {event, params} ->
+        socket = LocalStore.assign_cached(socket, :pending_action, nil)
+        handle_event(event, params, socket)
+    end
+  end
+
+  @impl true
   def handle_info({:authenticated, user}, socket) do
     socket =
       socket
@@ -322,8 +353,8 @@ defmodule AlgoraWeb.Org.BountiesNewLive do
     else
       {:noreply,
        socket
-       |> assign(:pending_action, {event, unsigned_params})
-       |> push_event("open_popup", %{url: socket.assigns.oauth_url})}
+       |> LocalStore.assign_cached(:pending_action, {event, unsigned_params})
+       |> redirect(external: socket.assigns.oauth_url)}
     end
   end
 

--- a/lib/algora_web/live/org/settings_live.ex
+++ b/lib/algora_web/live/org/settings_live.ex
@@ -10,13 +10,18 @@ defmodule AlgoraWeb.Org.SettingsLive do
   alias Algora.Markdown
   alias Algora.Payments
   alias AlgoraWeb.Components.Logos
+  alias AlgoraWeb.LocalStore
 
   require Logger
 
   @impl true
   def render(assigns) do
     ~H"""
-    <div class="container mx-auto max-w-7xl space-y-6 p-4 sm:px-6 lg:px-8">
+    <div
+      id="org-settings-page"
+      class="container mx-auto max-w-7xl space-y-6 p-4 sm:px-6 lg:px-8"
+      phx-hook="LocalStateStore"
+    >
       <div class="space-y-1">
         <h1 class="text-2xl font-bold">Settings</h1>
         <p class="text-muted-foreground">Update your settings and preferences</p>
@@ -248,7 +253,8 @@ defmodule AlgoraWeb.Org.SettingsLive do
      socket
      |> assign(:has_fresh_token?, Accounts.has_fresh_token?(socket.assigns.current_user))
      |> assign(:installations, installations)
-     |> assign(:oauth_url, Github.authorize_url(%{socket_id: socket.id}))
+     |> assign(:oauth_url, Github.authorize_url(%{return_to: "/#{current_org.handle}/settings"}))
+     |> assign(:pending_action, nil)
      |> assign_has_default_payment_method()
      |> assign(:template_form, to_form(template_changeset))
      |> assign(:template_preview, preview_template(socket, template))
@@ -285,8 +291,8 @@ defmodule AlgoraWeb.Org.SettingsLive do
        redirect(socket, external: Github.install_url_select_target())
      else
        socket
-       |> assign(:pending_action, {event, unsigned_params})
-       |> push_event("open_popup", %{url: socket.assigns.oauth_url})
+       |> LocalStore.assign_cached(:pending_action, {event, unsigned_params})
+       |> redirect(external: socket.assigns.oauth_url)
      end}
   end
 
@@ -361,13 +367,31 @@ defmodule AlgoraWeb.Org.SettingsLive do
   end
 
   @impl true
+  def handle_event("restore_settings", params, socket) do
+    socket = LocalStore.restore(socket, params)
+
+    case socket.assigns.pending_action do
+      nil ->
+        {:noreply, socket}
+
+      {event, params} ->
+        socket = LocalStore.assign_cached(socket, :pending_action, nil)
+        handle_event(event, params, socket)
+    end
+  end
+
+  @impl true
   def handle_event(_event, _params, socket) do
     {:noreply, socket}
   end
 
   @impl true
   def handle_params(params, _url, socket) do
-    {:noreply, apply_action(socket, socket.assigns.live_action, params)}
+    {:noreply,
+     socket
+     |> LocalStore.init(key: __MODULE__)
+     |> LocalStore.subscribe()
+     |> apply_action(socket.assigns.live_action, params)}
   end
 
   defp apply_action(socket, :edit, _params) do

--- a/lib/algora_web/live/swift_bounties_live.ex
+++ b/lib/algora_web/live/swift_bounties_live.ex
@@ -15,6 +15,7 @@ defmodule AlgoraWeb.SwiftBountiesLive do
   alias AlgoraWeb.Components.Logos
   alias AlgoraWeb.Forms.BountyForm
   alias AlgoraWeb.Forms.TipForm
+  alias AlgoraWeb.LocalStore
   alias AlgoraWeb.UserAuth
 
   require Logger
@@ -34,7 +35,7 @@ defmodule AlgoraWeb.SwiftBountiesLive do
           |> assign(:page_image, "#{AlgoraWeb.Endpoint.url()}/images/og/swift.png")
           |> assign(:bounty_form, to_form(BountyForm.changeset(%BountyForm{}, %{})))
           |> assign(:tip_form, to_form(TipForm.changeset(%TipForm{}, %{})))
-          |> assign(:oauth_url, Github.authorize_url(%{socket_id: socket.id}))
+          |> assign(:oauth_url, Github.authorize_url(%{return_to: "/swift"}))
           |> assign(:pending_action, nil)
           |> assign_bounties()
           |> assign_active_repos()
@@ -48,7 +49,11 @@ defmodule AlgoraWeb.SwiftBountiesLive do
 
   def render(assigns) do
     ~H"""
-    <div class="relative isolate overflow-hidden bg-background">
+    <div
+      id="swift-bounties-page"
+      class="relative isolate overflow-hidden bg-background"
+      phx-hook="LocalStateStore"
+    >
       <svg
         class="[mask-image:radial-gradient(100%_100%_at_top_right,white,transparent)] absolute inset-0 -z-10 size-full stroke-white/10"
         aria-hidden="true"
@@ -497,6 +502,28 @@ defmodule AlgoraWeb.SwiftBountiesLive do
     """
   end
 
+  @impl true
+  def handle_params(_params, _uri, socket) do
+    {:noreply,
+     socket
+     |> LocalStore.init(key: __MODULE__)
+     |> LocalStore.subscribe()}
+  end
+
+  @impl true
+  def handle_event("restore_settings", params, socket) do
+    socket = LocalStore.restore(socket, params)
+
+    case socket.assigns.pending_action do
+      nil ->
+        {:noreply, socket}
+
+      {event, params} ->
+        socket = LocalStore.assign_cached(socket, :pending_action, nil)
+        handle_event(event, params, socket)
+    end
+  end
+
   defp create_bounty(assigns) do
     ~H"""
     <.card class="bg-muted/30">
@@ -583,8 +610,8 @@ defmodule AlgoraWeb.SwiftBountiesLive do
       else
         {:noreply,
          socket
-         |> assign(:pending_action, {event, unsigned_params})
-         |> push_event("open_popup", %{url: socket.assigns.oauth_url})}
+         |> LocalStore.assign_cached(:pending_action, {event, unsigned_params})
+         |> redirect(external: socket.assigns.oauth_url)}
       end
     else
       {:noreply, assign(socket, :bounty_form, to_form(changeset))}
@@ -619,8 +646,8 @@ defmodule AlgoraWeb.SwiftBountiesLive do
       else
         {:noreply,
          socket
-         |> assign(:pending_action, {event, unsigned_params})
-         |> push_event("open_popup", %{url: socket.assigns.oauth_url})}
+         |> LocalStore.assign_cached(:pending_action, {event, unsigned_params})
+         |> redirect(external: socket.assigns.oauth_url)}
       end
     else
       {:noreply, assign(socket, :tip_form, to_form(changeset))}


### PR DESCRIPTION
## Summary

This finishes the remaining OAuth popup migrations from #137, but keeps the pending action alive across the redirect round trip.

The important bit is that these flows cannot just redirect to GitHub and hope the old LiveView socket is still around. Before leaving the page, the pending action is now cached through `AlgoraWeb.LocalStore`; when GitHub redirects back, the page restores that state and replays the original action.

Updated flows:

- Crowdfund bounty/tip creation
- Swift bounty/tip creation
- Org bounty creation
- Org settings GitHub app installation

Fixes #137

## Checks

- Parsed the touched LiveView files with Elixir's parser
- `git diff --check`