### PR TITLE
Fix: setup_payout_account returns error flash instead of Stripe Connect redirect (#274)

### DIFF
--- a/lib/algora/payments/payments.ex
+++ b/lib/algora/payments/payments.ex
@@ -303,14 +303,14 @@ defmodule Algora.Payments do
     end
   end
 
-  @spec create_account_link(account :: Account.t(), base_url :: String.t()) ::
+  @spec create_account_link(account :: Account.t(), base_url :: String.t(), type :: String.t()) ::
           {:ok, PSP.account_link()} | {:error, PSP.error()}
-  def create_account_link(account, base_url) do
+  def create_account_link(account, base_url, type \\ "account_onboarding") do
     PSP.AccountLink.create(%{
       account: account.provider_id,
       refresh_url: "#{base_url}/callbacks/stripe/refresh",
       return_url: "#{base_url}/callbacks/stripe/return",
-      type: "account_onboarding"
+      type: type
     })
   end
 

--- a/lib/algora_web/live/org/transactions_live.ex
+++ b/lib/algora_web/live/org/transactions_live.ex
@@ -77,7 +77,9 @@ defmodule AlgoraWeb.Org.TransactionsLive do
   end
 
   def handle_event("setup_payout_account", _params, socket) do
-    case Payments.create_account_link(socket.assigns.account, AlgoraWeb.Endpoint.url()) do
+    type = if socket.assigns.account.details_submitted, do: "account_update", else: "account_onboarding"
+
+    case Payments.create_account_link(socket.assigns.account, AlgoraWeb.Endpoint.url(), type) do
       {:ok, %{url: url}} -> {:noreply, redirect(socket, external: url)}
       {:error, _reason} -> {:noreply, put_flash(socket, :error, "Something went wrong")}
     end

--- a/lib/algora_web/live/user/transactions_live.ex
+++ b/lib/algora_web/live/user/transactions_live.ex
@@ -75,7 +75,9 @@ defmodule AlgoraWeb.User.TransactionsLive do
   end
 
   def handle_event("setup_payout_account", _params, socket) do
-    case Payments.create_account_link(socket.assigns.account, AlgoraWeb.Endpoint.url()) do
+    type = if socket.assigns.account.details_submitted, do: "account_update", else: "account_onboarding"
+
+    case Payments.create_account_link(socket.assigns.account, AlgoraWeb.Endpoint.url(), type) do
       {:ok, %{url: url}} ->
         {:noreply, redirect(socket, external: url)}
 


### PR DESCRIPTION
Fixes #274

### Bug
When an existing user (who had already partially or fully completed Stripe onboarding) clicked the **Update details** button, they were greeted with a `Something went wrong` error flash instead of being redirected to Stripe Connect. This was because the `setup_payout_account` handler unconditionally requested an `account_onboarding` account link type, which fails via the Stripe API if the account has already submitted its details. The API returned an error that was being swallowed by a catch-all `{:error, _reason}` match.

### Fix
- Updated `Payments.create_account_link/3` to accept a `type` argument (defaulting to `"account_onboarding"`).
- Updated the `setup_payout_account` event handlers in both the User and Org `transactions_live.ex` modules to dynamically check `socket.assigns.account.details_submitted`. If true, the link type is correctly set to `"account_update"`, restoring the ability for users to update their payout details.