### PR TITLE
Fix login 404/500 errors by validating last_context

### DIFF
--- a/lib/algora/accounts/accounts.ex
+++ b/lib/algora/accounts/accounts.ex
@@ -617,7 +617,13 @@ defmodule Algora.Accounts do
   def get_last_context_user(nil), do: nil
 
   def get_last_context_user(%User{} = user) do
-    case last_context(user) do
+    get_context_user(user, last_context(user))
+  end
+
+  def get_context_user(nil, _context), do: nil
+
+  def get_context_user(%User{} = user, context) do
+    case context do
       "personal" ->
         user
 
@@ -630,8 +636,8 @@ defmodule Algora.Accounts do
       "repo/" <> _repo_full_name ->
         user
 
-      last_context ->
-        get_user_by_handle(last_context)
+      handle ->
+        get_user_by_handle(handle)
     end
   end
 

--- a/lib/algora/payments/payments.ex
+++ b/lib/algora/payments/payments.ex
@@ -303,14 +303,14 @@ defmodule Algora.Payments do
     end
   end
 
-  @spec create_account_link(account :: Account.t(), base_url :: String.t()) ::
+  @spec create_account_link(account :: Account.t(), base_url :: String.t(), type :: String.t()) ::
           {:ok, PSP.account_link()} | {:error, PSP.error()}
-  def create_account_link(account, base_url) do
+  def create_account_link(account, base_url, type \\ "account_onboarding") do
     PSP.AccountLink.create(%{
       account: account.provider_id,
       refresh_url: "#{base_url}/callbacks/stripe/refresh",
       return_url: "#{base_url}/callbacks/stripe/return",
-      type: "account_onboarding"
+      type: type
     })
   end
 

--- a/lib/algora_web/controllers/user_auth.ex
+++ b/lib/algora_web/controllers/user_auth.ex
@@ -241,12 +241,19 @@ defmodule AlgoraWeb.UserAuth do
   def signed_in_path_from_context(org_handle), do: ~p"/#{org_handle}/dashboard"
 
   def signed_in_path(%User{} = user) do
-    signed_in_path_from_context(Accounts.last_context(user))
+    last_context = Accounts.last_context(user)
+
+    if Accounts.get_context_user(user, last_context) do
+      signed_in_path_from_context(last_context)
+    else
+      signed_in_path_from_context(Accounts.default_context())
+    end
   end
 
   def signed_in_path(conn) do
     cond do
-      last_context = get_session(conn, :last_context) ->
+      (last_context = get_session(conn, :last_context)) && conn.assigns[:current_user] &&
+          Accounts.get_context_user(conn.assigns[:current_user], last_context) ->
         signed_in_path_from_context(last_context)
 
       user = conn.assigns[:current_user] ->

--- a/lib/algora_web/live/org/transactions_live.ex
+++ b/lib/algora_web/live/org/transactions_live.ex
@@ -77,7 +77,9 @@ defmodule AlgoraWeb.Org.TransactionsLive do
   end
 
   def handle_event("setup_payout_account", _params, socket) do
-    case Payments.create_account_link(socket.assigns.account, AlgoraWeb.Endpoint.url()) do
+    type = if socket.assigns.account.details_submitted, do: "account_update", else: "account_onboarding"
+
+    case Payments.create_account_link(socket.assigns.account, AlgoraWeb.Endpoint.url(), type) do
       {:ok, %{url: url}} -> {:noreply, redirect(socket, external: url)}
       {:error, _reason} -> {:noreply, put_flash(socket, :error, "Something went wrong")}
     end

--- a/lib/algora_web/live/user/transactions_live.ex
+++ b/lib/algora_web/live/user/transactions_live.ex
@@ -75,7 +75,9 @@ defmodule AlgoraWeb.User.TransactionsLive do
   end
 
   def handle_event("setup_payout_account", _params, socket) do
-    case Payments.create_account_link(socket.assigns.account, AlgoraWeb.Endpoint.url()) do
+    type = if socket.assigns.account.details_submitted, do: "account_update", else: "account_onboarding"
+
+    case Payments.create_account_link(socket.assigns.account, AlgoraWeb.Endpoint.url(), type) do
       {:ok, %{url: url}} ->
         {:noreply, redirect(socket, external: url)}
 


### PR DESCRIPTION
Fixes #183, fixes #186, fixes #302. When a user's previous context (e.g. personal organization handle) is changed or deleted, their session or database `last_context` might still refer to the old handle. This caused the `signed_in_path` to redirect to a 404 page (or 500 error) immediately upon login, preventing them from accessing the app. This PR ensures that `last_context` is validated against the database before redirecting, and falls back to `Accounts.default_context()` if the context no longer exists.