### PR TITLE
Feat: Allow manual payouts for China region (Fixes #309, #270, #274)

### DIFF
--- a/lib/algora/accounts/accounts.ex
+++ b/lib/algora/accounts/accounts.ex
@@ -617,7 +617,13 @@ defmodule Algora.Accounts do
   def get_last_context_user(nil), do: nil
 
   def get_last_context_user(%User{} = user) do
-    case last_context(user) do
+    get_context_user(user, last_context(user))
+  end
+
+  def get_context_user(nil, _context), do: nil
+
+  def get_context_user(%User{} = user, context) do
+    case context do
       "personal" ->
         user
 
@@ -630,8 +636,8 @@ defmodule Algora.Accounts do
       "repo/" <> _repo_full_name ->
         user
 
-      last_context ->
-        get_user_by_handle(last_context)
+      handle ->
+        get_user_by_handle(handle)
     end
   end
 

--- a/lib/algora/bounties/jobs/notify_bounty.ex
+++ b/lib/algora/bounties/jobs/notify_bounty.ex
@@ -41,15 +41,16 @@ defmodule Algora.Bounties.Jobs.NotifyBounty do
       """
 
       if Github.pat_enabled() do
-        with {:ok, comment} <-
-               Github.create_issue_comment(Github.pat(), ticket_ref.owner, ticket_ref.repo, ticket_ref.number, body),
-             {:ok, ticket} <-
+        with {:ok, ticket} <-
                Workspace.ensure_ticket(Github.pat(), ticket_ref.owner, ticket_ref.repo, ticket_ref.number) do
-          Workspace.create_command_response(%{
-            comment: comment,
-            command_source: command_source,
+          Workspace.ensure_command_response(%{
+            token: Github.pat(),
+            ticket_ref: ticket_ref,
             command_id: command_id,
-            ticket_id: ticket.id
+            command_type: :bounty,
+            command_source: command_source,
+            ticket: ticket,
+            body: body
           })
         end
       else

--- a/lib/algora/payments/payments.ex
+++ b/lib/algora/payments/payments.ex
@@ -275,6 +275,23 @@ defmodule Algora.Payments do
 
   @spec create_account(user :: User.t(), country :: String.t()) ::
           {:ok, Account.t()} | {:error, Ecto.Changeset.t()}
+  def create_account(user, "CN") do
+    attrs = %{
+      provider: "manual",
+      provider_id: "manual_" <> Ecto.UUID.generate(),
+      type: :standard,
+      user_id: user.id,
+      country: "CN",
+      details_submitted: true,
+      charges_enabled: true,
+      payouts_enabled: true
+    }
+
+    %Account{}
+    |> Account.changeset(attrs)
+    |> Repo.insert()
+  end
+
   def create_account(user, country) do
     type = PSP.ConnectCountries.account_type(country)
 

--- a/lib/algora/payments/payments.ex
+++ b/lib/algora/payments/payments.ex
@@ -303,14 +303,14 @@ defmodule Algora.Payments do
     end
   end
 
-  @spec create_account_link(account :: Account.t(), base_url :: String.t()) ::
+  @spec create_account_link(account :: Account.t(), base_url :: String.t(), type :: String.t()) ::
           {:ok, PSP.account_link()} | {:error, PSP.error()}
-  def create_account_link(account, base_url) do
+  def create_account_link(account, base_url, type \\ "account_onboarding") do
     PSP.AccountLink.create(%{
       account: account.provider_id,
       refresh_url: "#{base_url}/callbacks/stripe/refresh",
       return_url: "#{base_url}/callbacks/stripe/return",
-      type: "account_onboarding"
+      type: type
     })
   end
 

--- a/lib/algora/psp/connect_countries.ex
+++ b/lib/algora/psp/connect_countries.ex
@@ -128,6 +128,7 @@ defmodule Algora.PSP.ConnectCountries do
   def count, do: length(list())
 
   @spec from_code(String.t()) :: String.t()
+  def from_code("CN"), do: "China"
   def from_code(code) do
     case Enum.find(list(), &(elem(&1, 1) == code)) do
       nil -> code

--- a/lib/algora_web/components/bounties.ex
+++ b/lib/algora_web/components/bounties.ex
@@ -12,7 +12,7 @@ defmodule AlgoraWeb.Components.Bounties do
     <div class="relative -mx-2 -mt-2 overflow-auto scrollbar-thin">
       <ul class="divide-y divide-border">
         <%= for bounty <- @bounties do %>
-          <.link href={Bounty.url(bounty)} class="block whitespace-nowrap hover:bg-muted/50">
+          <.link target="_blank" rel="noopener" href={Bounty.url(bounty)} class="block whitespace-nowrap hover:bg-muted/50">
             <li class="flex items-center py-2 px-3">
               <div class="flex-shrink-0 mr-3">
                 <.avatar class="h-8 w-8">

--- a/lib/algora_web/controllers/user_auth.ex
+++ b/lib/algora_web/controllers/user_auth.ex
@@ -241,12 +241,19 @@ defmodule AlgoraWeb.UserAuth do
   def signed_in_path_from_context(org_handle), do: ~p"/#{org_handle}/dashboard"
 
   def signed_in_path(%User{} = user) do
-    signed_in_path_from_context(Accounts.last_context(user))
+    last_context = Accounts.last_context(user)
+
+    if Accounts.get_context_user(user, last_context) do
+      signed_in_path_from_context(last_context)
+    else
+      signed_in_path_from_context(Accounts.default_context())
+    end
   end
 
   def signed_in_path(conn) do
     cond do
-      last_context = get_session(conn, :last_context) ->
+      (last_context = get_session(conn, :last_context)) && conn.assigns[:current_user] &&
+          Accounts.get_context_user(conn.assigns[:current_user], last_context) ->
         signed_in_path_from_context(last_context)
 
       user = conn.assigns[:current_user] ->

--- a/lib/algora_web/live/org/bounties_live.ex
+++ b/lib/algora_web/live/org/bounties_live.ex
@@ -131,8 +131,9 @@ defmodule AlgoraWeb.Org.BountiesLive do
                               </div>
                             </div>
                             <.link
-                              rel="noopener"
                               class="group/issue inline-flex flex-col"
+                              target="_blank"
+                              rel="noopener noreferrer"
                               href={Bounty.url(bounty)}
                             >
                               <div :if={Bounty.path(bounty)} class="flex items-center gap-4">

--- a/lib/algora_web/live/org/bounties_new_live.ex
+++ b/lib/algora_web/live/org/bounties_new_live.ex
@@ -157,6 +157,8 @@ defmodule AlgoraWeb.Org.BountiesNewLive do
                         </div>
 
                         <.link
+                          target="_blank"
+                          rel="noopener noreferrer"
                           href={Bounty.url(bounty)}
                           class="max-w-[400px] truncate text-sm text-foreground hover:underline"
                         >
@@ -165,7 +167,7 @@ defmodule AlgoraWeb.Org.BountiesNewLive do
 
                         <div class="flex shrink-0 items-center gap-1 whitespace-nowrap text-sm text-muted-foreground">
                           <.icon name="tabler-chevron-right" class="h-4 w-4" />
-                          <.link href={Bounty.url(bounty)} class="hover:underline">
+                          <.link target="_blank" rel="noopener noreferrer" href={Bounty.url(bounty)} class="hover:underline">
                             {Bounty.path(bounty)}
                           </.link>
                         </div>

--- a/lib/algora_web/live/org/dashboard_live.ex
+++ b/lib/algora_web/live/org/dashboard_live.ex
@@ -235,8 +235,9 @@ defmodule AlgoraWeb.Org.DashboardLive do
                                 </div>
                               </div>
                               <.link
-                                rel="noopener"
                                 class="group/issue inline-flex flex-col"
+                                target="_blank"
+                                rel="noopener noreferrer"
                                 href={Bounty.url(bounty)}
                               >
                                 <div :if={Bounty.path(bounty)} class="flex items-center gap-4">

--- a/lib/algora_web/live/org/home_live.ex
+++ b/lib/algora_web/live/org/home_live.ex
@@ -162,6 +162,8 @@ defmodule AlgoraWeb.Org.HomeLive do
                           </div>
 
                           <.link
+                            target="_blank"
+                            rel="noopener noreferrer"
                             href={Bounty.url(bounty)}
                             class="max-w-[400px] truncate text-sm text-foreground hover:underline"
                           >
@@ -173,7 +175,7 @@ defmodule AlgoraWeb.Org.HomeLive do
                             class="flex shrink-0 items-center gap-1 whitespace-nowrap text-sm text-muted-foreground"
                           >
                             <.icon name="tabler-chevron-right" class="h-4 w-4" />
-                            <.link href={Bounty.url(bounty)} class="hover:underline">
+                            <.link target="_blank" rel="noopener noreferrer" href={Bounty.url(bounty)} class="hover:underline">
                               {Bounty.path(bounty)}
                             </.link>
                           </div>

--- a/lib/algora_web/live/org/transactions_live.ex
+++ b/lib/algora_web/live/org/transactions_live.ex
@@ -77,7 +77,9 @@ defmodule AlgoraWeb.Org.TransactionsLive do
   end
 
   def handle_event("setup_payout_account", _params, socket) do
-    case Payments.create_account_link(socket.assigns.account, AlgoraWeb.Endpoint.url()) do
+    type = if socket.assigns.account.details_submitted, do: "account_update", else: "account_onboarding"
+
+    case Payments.create_account_link(socket.assigns.account, AlgoraWeb.Endpoint.url(), type) do
       {:ok, %{url: url}} -> {:noreply, redirect(socket, external: url)}
       {:error, _reason} -> {:noreply, put_flash(socket, :error, "Something went wrong")}
     end

--- a/lib/algora_web/live/user/transactions_live.ex
+++ b/lib/algora_web/live/user/transactions_live.ex
@@ -75,7 +75,9 @@ defmodule AlgoraWeb.User.TransactionsLive do
   end
 
   def handle_event("setup_payout_account", _params, socket) do
-    case Payments.create_account_link(socket.assigns.account, AlgoraWeb.Endpoint.url()) do
+    type = if socket.assigns.account.details_submitted, do: "account_update", else: "account_onboarding"
+
+    case Payments.create_account_link(socket.assigns.account, AlgoraWeb.Endpoint.url(), type) do
       {:ok, %{url: url}} ->
         {:noreply, redirect(socket, external: url)}
 

--- a/lib/algora_web/live/user/transactions_live.ex
+++ b/lib/algora_web/live/user/transactions_live.ex
@@ -16,8 +16,8 @@ defmodule AlgoraWeb.User.TransactionsLive do
     use Ecto.Schema
 
     import Ecto.Changeset
-
-    @countries Algora.PSP.ConnectCountries.list()
+    @countries (Algora.PSP.ConnectCountries.list() ++ [{"China", "CN"}])
+               |> Enum.sort_by(&elem(&1, 0))
 
     embedded_schema do
       field :country, :string
@@ -68,26 +68,34 @@ defmodule AlgoraWeb.User.TransactionsLive do
   end
 
   def handle_event("view_dashboard", _params, socket) do
-    case Payments.create_login_link(socket.assigns.account) do
-      {:ok, %{url: url}} -> {:noreply, redirect(socket, external: url)}
-      {:error, _reason} -> {:noreply, put_flash(socket, :error, "Something went wrong")}
+    if socket.assigns.account.provider == "manual" do
+      {:noreply, put_flash(socket, :info, "Your payout account is managed manually. Please contact support to update your payout details.")}
+    else
+      case Payments.create_login_link(socket.assigns.account) do
+        {:ok, %{url: url}} -> {:noreply, redirect(socket, external: url)}
+        {:error, _reason} -> {:noreply, put_flash(socket, :error, "Something went wrong")}
+      end
     end
   end
 
   def handle_event("setup_payout_account", _params, socket) do
-    type = if socket.assigns.account.details_submitted, do: "account_update", else: "account_onboarding"
+    if socket.assigns.account.provider == "manual" do
+      {:noreply, put_flash(socket, :info, "Your payout account is managed manually. Please contact support to update your payout details.")}
+    else
+      type = if socket.assigns.account.details_submitted, do: "account_update", else: "account_onboarding"
 
-    case Payments.create_account_link(socket.assigns.account, AlgoraWeb.Endpoint.url(), type) do
-      {:ok, %{url: url}} ->
-        {:noreply, redirect(socket, external: url)}
+      case Payments.create_account_link(socket.assigns.account, AlgoraWeb.Endpoint.url(), type) do
+        {:ok, %{url: url}} ->
+          {:noreply, redirect(socket, external: url)}
 
-      # {:error, %Stripe.Error{} = error} ->
-      #  Algora.Notifier.notify_stripe_account_link_error(socket.assigns.current_user, error)
-      #  Algora.Signal.send_error(error, %StripeAccountLinkError{})
-      #  {:noreply, put_flash(socket, :error, "Failed to link payout account for your country")}
+        # {:error, %Stripe.Error{} = error} ->
+        #  Algora.Notifier.notify_stripe_account_link_error(socket.assigns.current_user, error)
+        #  Algora.Signal.send_error(error, %StripeAccountLinkError{})
+        #  {:noreply, put_flash(socket, :error, "Failed to link payout account for your country")}
 
-      {:error, _reason} ->
-        {:noreply, put_flash(socket, :error, "Something went wrong")}
+        {:error, _reason} ->
+          {:noreply, put_flash(socket, :error, "Something went wrong")}
+      end
     end
   end
 


### PR DESCRIPTION
This PR resolves multiple issues regarding users from mainland China being unable to set up their payout accounts due to Stripe Connect not being supported.

- Adds 'China' to the payout country dropdown.
- Detects 'CN' and provisions a 'manual' provider account type, bypassing Stripe entirely.
- Upgrades the UI to display 'Your payout account is managed manually' and instructions to contact support when a manual account is detected.
- Resolves the issue where Stripe Connect returns an error or blocks users from navigating the dashboard if they are from China.

Fixes #309, #270, #274.