### PR TITLE
Hide bounty actions from unauthorized users

### DIFF
--- a/lib/algora_web/live/org/bounties_live.ex
+++ b/lib/algora_web/live/org/bounties_live.ex
@@ -220,7 +220,10 @@ defmodule AlgoraWeb.Org.BountiesLive do
                       <% end %>
                     </td>
                     <td class="[&:has([role=checkbox])]:pr-0 p-4 align-middle">
-                      <div class="flex items-center justify-end gap-2">
+                      <div
+                        :if={can_manage_bounties?(@current_user_role)}
+                        class="flex items-center justify-end gap-2"
+                      >
                         <.button
                           phx-click="edit-bounty-amount"
                           phx-value-id={bounty.id}
@@ -415,7 +418,7 @@ defmodule AlgoraWeb.Org.BountiesLive do
 
   def handle_event("delete-bounty", %{"id" => bounty_id}, socket) do
     cond do
-      socket.assigns.current_user_role in [:admin, :mod] ->
+      can_manage_bounties?(socket.assigns.current_user_role) ->
         bounty =
           Bounty
           |> Repo.get(bounty_id)
@@ -475,7 +478,7 @@ defmodule AlgoraWeb.Org.BountiesLive do
 
   def handle_event("edit-bounty-amount", %{"id" => bounty_id}, socket) do
     cond do
-      socket.assigns.current_user_role in [:admin, :mod] ->
+      can_manage_bounties?(socket.assigns.current_user_role) ->
         [bounty] = Bounties.list_bounties(id: bounty_id)
         changeset = edit_amount_changeset(%{amount: bounty.amount})
 
@@ -706,4 +709,6 @@ defmodule AlgoraWeb.Org.BountiesLive do
 
     assign(socket, :bounty_rows, to_bounty_rows(bounties))
   end
+
+  defp can_manage_bounties?(role), do: role in [:admin, :mod]
 end


### PR DESCRIPTION
Closes #238.`n`n## Summary`n- Hide the Edit Amount and Delete controls unless the current org role can manage bounties.`n- Reuse the same helper in the LiveView event handlers so UI visibility and server-side authorization stay aligned.`n`n## Verification`n- Not run locally; full repository clone timed out in this environment.`n- Verified the remote branch diff contains one changed file: lib/algora_web/live/org/bounties_live.ex.