### PR TITLE
fix: clarify claim reward payment status

### DIFF
--- a/lib/algora_web/live/claim_live.ex
+++ b/lib/algora_web/live/claim_live.ex
@@ -124,6 +124,8 @@ defmodule AlgoraWeb.ClaimLive do
           |> Enum.sort_by(&{&1.pledged, &1.paid, &1.sponsor.name}, :desc)
 
         source_or_target = primary_claim.source || primary_claim.target
+        claim_status_label = claim_status_label(primary_claim, sponsors)
+        show_claim_payment_hint = show_claim_payment_hint?(primary_claim, sponsors)
 
         contexts =
           if socket.assigns.current_user do
@@ -145,6 +147,8 @@ defmodule AlgoraWeb.ClaimLive do
          |> assign(:target, primary_claim.target)
          |> assign(:source, primary_claim.source)
          |> assign(:source_or_target, source_or_target)
+         |> assign(:claim_status_label, claim_status_label)
+         |> assign(:show_claim_payment_hint, show_claim_payment_hint)
          |> assign(:bounties, primary_claim.target.bounties)
          |> assign(:prize_pool, prize_pool)
          |> assign(:total_paid, total_paid)
@@ -209,6 +213,24 @@ defmodule AlgoraWeb.ClaimLive do
         {:noreply, assign(socket, :reward_bounty_form, to_form(changeset))}
     end
   end
+
+  defp claim_status_label(%Claim{status: status}, _sponsors) when status != :approved do
+    status |> to_string() |> String.capitalize()
+  end
+
+  defp claim_status_label(%Claim{status: :approved}, sponsors) do
+    cond do
+      Enum.all?(sponsors, &(&1.status in [:paid, :overpaid])) -> "Rewarded"
+      Enum.any?(sponsors, &(&1.status == :partial)) -> "Partially rewarded"
+      true -> "Awaiting sponsor reward"
+    end
+  end
+
+  defp show_claim_payment_hint?(%Claim{status: :approved}, sponsors) do
+    Enum.any?(sponsors, &(&1.status in [:pending, :partial]))
+  end
+
+  defp show_claim_payment_hint?(_claim, _sponsors), do: false
 
   defp default_context_id(socket) do
     case socket.assigns.available_bounties do
@@ -398,7 +420,10 @@ defmodule AlgoraWeb.ClaimLive do
                 </div>
                 <div class="flex justify-between text-sm">
                   <span class="text-muted-foreground">Status</span>
-                  <span>{@primary_claim.status |> to_string() |> String.capitalize()}</span>
+                  <span>{@claim_status_label}</span>
+                </div>
+                <div :if={@show_claim_payment_hint} class="text-sm text-muted-foreground">
+                  No contributor action is required. This claim is approved and waiting for the sponsor reward to be completed.
                 </div>
                 <div class="flex justify-between text-sm">
                   <span class="text-muted-foreground">Submitted</span>

--- a/test/algora_web/live/claim_live_test.exs
+++ b/test/algora_web/live/claim_live_test.exs
@@ -1,0 +1,49 @@
+defmodule AlgoraWeb.ClaimLiveTest do
+  use AlgoraWeb.ConnCase, async: true
+
+  import Algora.Factory
+  import Phoenix.LiveViewTest
+
+  describe "payment status" do
+    test "shows approved claims as awaiting sponsor reward until the bounty is paid", %{conn: conn} do
+      %{group_id: group_id} = create_claim_with_reward_status(:pending)
+
+      assert {:ok, _view, html} = live(conn, ~p"/claims/#{group_id}")
+
+      assert html =~ "Awaiting sponsor reward"
+      assert html =~ "No contributor action is required"
+    end
+
+    test "shows rewarded after the sponsor payment succeeds", %{conn: conn} do
+      %{group_id: group_id} = create_claim_with_reward_status(:paid)
+
+      assert {:ok, _view, html} = live(conn, ~p"/claims/#{group_id}")
+
+      assert html =~ "Rewarded"
+      refute html =~ "Awaiting sponsor reward"
+    end
+  end
+
+  defp create_claim_with_reward_status(status) do
+    sponsor = insert!(:organization)
+    contributor = insert!(:user)
+    repository = insert!(:repository, user: sponsor)
+    target = insert!(:ticket, repository: repository)
+    bounty = insert!(:bounty, owner: sponsor, creator: sponsor, ticket: target, amount: Money.new!(100, :USD))
+    claim = insert!(:claim, target: target, user: contributor, status: :approved)
+
+    if status == :paid do
+      insert!(
+        :transaction,
+        claim: claim,
+        bounty: bounty,
+        user: sponsor,
+        type: :debit,
+        status: :succeeded,
+        net_amount: Money.new!(100, :USD)
+      )
+    end
+
+    %{group_id: claim.group_id}
+  end
+end


### PR DESCRIPTION
## Summary
- Derive the public claim status from sponsor payment progress instead of showing only the claim approval state.
- Show approved/unpaid claims as "Awaiting sponsor reward" and fully paid claims as "Rewarded".
- Add copy clarifying that approved claims waiting on sponsor reward require no contributor-side action.
- Add LiveView coverage for pending and paid claim reward states.

## Test Plan
- [x] Added regression tests in `test/algora_web/live/claim_live_test.exs`
- [ ] `mix test test/algora_web/live/claim_live_test.exs` (not run locally: this environment does not have Elixir/Mix installed; command fails with `mix: command not found`)

Closes #262