### PR TITLE
fix(ui): hide unauthorized edit/delete bounty buttons

### DIFF
--- a/lib/algora_web/components/bounties.ex
+++ b/lib/algora_web/components/bounties.ex
@@ -24,17 +24,22 @@ defmodule AlgoraWeb.Components.Bounties do
               </div>
 
               <div class="flex-grow min-w-0 mr-4">
-                <div class="flex items-center text-sm">
-                  <span class="font-semibold mr-1">
-                    {bounty.repository.owner.name || bounty.owner.name}
+                <div class="flex items-center justify-between text-sm w-full">
+                  <div class="flex items-center truncate">
+                    <span class="font-semibold mr-1 flex-shrink-0">
+                      {bounty.repository.owner.name || bounty.owner.name}
+                    </span>
+                    <span :if={bounty.ticket.number} class="text-muted-foreground mr-2 flex-shrink-0">
+                      #{bounty.ticket.number}
+                    </span>
+                    <span class="font-display whitespace-nowrap text-sm font-semibold tabular-nums text-success mr-2 flex-shrink-0">
+                      {Money.to_string!(bounty.amount)}
+                    </span>
+                    <span class="text-foreground truncate">{bounty.ticket.title}</span>
+                  </div>
+                  <span class="text-xs text-muted-foreground whitespace-nowrap ml-2 hidden sm:inline flex-shrink-0">
+                    {Algora.Util.time_ago(bounty.inserted_at)}
                   </span>
-                  <span :if={bounty.ticket.number} class="text-muted-foreground mr-2">
-                    #{bounty.ticket.number}
-                  </span>
-                  <span class="font-display whitespace-nowrap text-sm font-semibold tabular-nums text-success mr-2">
-                    {Money.to_string!(bounty.amount)}
-                  </span>
-                  <span class="text-foreground">{bounty.ticket.title}</span>
                 </div>
               </div>
             </li>

--- a/lib/algora_web/live/org/bounties_live.ex
+++ b/lib/algora_web/live/org/bounties_live.ex
@@ -220,24 +220,26 @@ defmodule AlgoraWeb.Org.BountiesLive do
                       <% end %>
                     </td>
                     <td class="[&:has([role=checkbox])]:pr-0 p-4 align-middle">
-                      <div class="flex items-center justify-end gap-2">
-                        <.button
-                          phx-click="edit-bounty-amount"
-                          phx-value-id={bounty.id}
-                          variant="secondary"
-                          size="sm"
-                        >
-                          Edit Amount
-                        </.button>
-                        <.button
-                          phx-click="delete-bounty"
-                          phx-value-id={bounty.id}
-                          variant="destructive"
-                          size="sm"
-                        >
-                          Delete
-                        </.button>
-                      </div>
+                      <%= if @current_user_role in [:admin, :mod] do %>
+                        <div class="flex items-center justify-end gap-2">
+                          <.button
+                            phx-click="edit-bounty-amount"
+                            phx-value-id={bounty.id}
+                            variant="secondary"
+                            size="sm"
+                          >
+                            Edit Amount
+                          </.button>
+                          <.button
+                            phx-click="delete-bounty"
+                            phx-value-id={bounty.id}
+                            variant="destructive"
+                            size="sm"
+                          >
+                            Delete
+                          </.button>
+                        </div>
+                      <% end %>
                     </td>
                   </tr>
                   <%= if MapSet.member?(@expanded_bounties, bounty.id) do %>


### PR DESCRIPTION
Fixes #238

**Description**
On the bounties listing page, the "Edit Amount" and "Delete" buttons were being rendered for all users, regardless of authorization. This PR wraps the buttons in an authorization check (`if @current_user_role in [:admin, :mod] do`) so they are hidden from users who do not have administrative permissions over the bounty. The backend check already existed; this PR aligns the UI.

**Changes**
- In `lib/algora_web/live/org/bounties_live.ex`, gated the display of action buttons based on the user's role.
