### PR TITLE
fix(bounties): exclusive visibility no longer bypasses tech stack filter

### DIFF
--- a/lib/algora/bounties/bounties.ex
+++ b/lib/algora/bounties/bounties.ex
@@ -1269,7 +1269,7 @@ defmodule Algora.Bounties do
 
       {:tech_stack, tech_stack}, query ->
         from([b, r: r] in query,
-          where: b.visibility == :exclusive or fragment("? && ?::citext[]", r.tech_stack, ^tech_stack)
+          where: fragment("? && ?::citext[]", r.tech_stack, ^tech_stack)
         )
 
       {:amount_gt, min_amount}, query ->


### PR DESCRIPTION
Fixes #173

**Description**
When users visited `/bounties/{language}` (e.g., `/bounties/svelte`), the tech stack filter was not being applied properly because bounties with `visibility == :exclusive` bypassed the tech stack check in `apply_criteria/2` entirely.

This PR fixes the issue by requiring that if a tech stack filter is provided, it correctly matches the bounty's repository tech stack without being bypassed by the bounty's exclusive visibility status. This ensures that the page accurately lists only the bounties for the requested language.
