### PR TITLE
fix: hide bounty actions from unauthorized users

### DIFF
--- a/lib/algora_web/live/org/bounties_live.ex
+++ b/lib/algora_web/live/org/bounties_live.ex
@@ -220,7 +220,7 @@ defmodule AlgoraWeb.Org.BountiesLive do
                       <% end %>
                     </td>
                     <td class="[&:has([role=checkbox])]:pr-0 p-4 align-middle">
-                      <div class="flex items-center justify-end gap-2">
+                      <div :if={@current_user_role in [:admin, :mod]} class="flex items-center justify-end gap-2">
                         <.button
                           phx-click="edit-bounty-amount"
                           phx-value-id={bounty.id}


### PR DESCRIPTION
## Summary
- only render the Edit Amount and Delete controls for org admins and mods
- keep the existing backend authorization checks intact
- remove the confusing UI path for viewers who cannot perform those actions

Closes #238

## Validation
- reviewed `AlgoraWeb.Org.BountiesLive` to confirm `current_user_role` is already assigned by org navigation
- unable to run `mix` in this environment because Elixir tooling is not installed on this machine
