### PR TITLE
fix: redirect personal logins to a valid page

### DIFF
--- a/lib/algora_web/controllers/user_auth.ex
+++ b/lib/algora_web/controllers/user_auth.ex
@@ -229,12 +229,12 @@ defmodule AlgoraWeb.UserAuth do
 
   defp maybe_store_return_to(conn), do: conn
 
-  def signed_in_path_from_context("personal"), do: ~p"/home"
+  def signed_in_path_from_context("personal"), do: ~p"/bounties"
 
   def signed_in_path_from_context("preview/" <> ctx) do
     case String.split(ctx, "/") do
       [_id, repo_owner, repo_name] -> ~p"/go/#{repo_owner}/#{repo_name}"
-      _ -> ~p"/home"
+      _ -> ~p"/bounties"
     end
   end
 

--- a/test/algora_web/controllers/user_auth_test.exs
+++ b/test/algora_web/controllers/user_auth_test.exs
@@ -143,4 +143,11 @@ defmodule AlgoraWeb.UserAuthTest do
       assert result == id
     end
   end
+
+  describe "signed_in_path/1" do
+    test "routes personal context users to the authenticated bounties page" do
+      assert UserAuth.signed_in_path_from_context("personal") == "/bounties"
+      assert UserAuth.signed_in_path_from_context("preview/bad/context") == "/bounties"
+    end
+  end
 end


### PR DESCRIPTION
## Summary
- send personal-context sign-ins to /bounties instead of /home
- use the same safe fallback for malformed preview contexts
- add a focused regression test for the personal-context path helper

Closes #329

## Validation
- added a regression assertion in UserAuthTest for the personal and malformed preview context cases
- unable to run mix test in this environment because Elixir tooling is not installed on this machine
