### PR TITLE
fix: open external bounty links in a new tab

### DIFF
--- a/lib/algora_web/components/bounties.ex
+++ b/lib/algora_web/components/bounties.ex
@@ -12,7 +12,12 @@ defmodule AlgoraWeb.Components.Bounties do
     <div class="relative -mx-2 -mt-2 overflow-auto scrollbar-thin">
       <ul class="divide-y divide-border">
         <%= for bounty <- @bounties do %>
-          <.link href={Bounty.url(bounty)} class="block whitespace-nowrap hover:bg-muted/50">
+          <.link
+            href={Bounty.url(bounty)}
+            target="_blank"
+            rel="noopener noreferrer"
+            class="block whitespace-nowrap hover:bg-muted/50"
+          >
             <li class="flex items-center py-2 px-3">
               <div class="flex-shrink-0 mr-3">
                 <.avatar class="h-8 w-8">


### PR DESCRIPTION
## Summary
- open bounty links rendered by the shared bounties list in a new tab
- add rel="noopener noreferrer" for the external navigation
- preserve the existing list behavior while keeping the Algora page in place

Closes #176

## Validation
- reviewed the shared `AlgoraWeb.Components.Bounties` component to confirm this is the common link surface for the bounty lists
- unable to run `mix` in this environment because Elixir tooling is not installed on this machine
