### PR TITLE
fix: redirect to /bounties after login instead of /home 404

### DIFF
--- a/lib/algora_web/controllers/user_auth.ex
+++ b/lib/algora_web/controllers/user_auth.ex
@@ -229,12 +229,12 @@ defmodule AlgoraWeb.UserAuth do
 
   defp maybe_store_return_to(conn), do: conn
 
-  def signed_in_path_from_context("personal"), do: ~p"/home"
+  def signed_in_path_from_context("personal"), do: ~p"/bounties"
 
   def signed_in_path_from_context("preview/" <> ctx) do
     case String.split(ctx, "/") do
       [_id, repo_owner, repo_name] -> ~p"/go/#{repo_owner}/#{repo_name}"
-      _ -> ~p"/home"
+      _ -> ~p"/bounties"
     end
   end
 
@@ -343,7 +343,7 @@ defmodule AlgoraWeb.UserAuth do
   def login_path(email, token, return_to),
     do: ~p"/callbacks/email/oauth?email=#{email}&token=#{token}&return_to=#{return_to}"
 
-  def generate_login_path(email, return_to \\ nil), do: login_path(email, generate_login_code(email), return_to)
+  def generate_login_path(email, return_to \ nil), do: login_path(email, generate_login_code(email), return_to)
 
   def generate_totp do
     secret = NimbleTOTP.secret()


### PR DESCRIPTION
## Summary

Fixes the post-login redirect bug reported in #329. After successful GitHub OAuth authentication, users were being redirected to `/home` which returns a 404 page.

## Root Cause

In `lib/algora_web/controllers/user_auth.ex`, the function `signed_in_path_from_context("personal")` returned `~p"/home"`, but no such route exists in `lib/algora_web/router.ex`. This caused every new user logging in with a personal context to land on a 404 page.

## Fix

Changed both occurrences of the broken `~p"/home"` redirect to `~p"/bounties"`:
- `signed_in_path_from_context("personal")` 
- The fallback case in `signed_in_path_from_context("preview/" <> ctx)`

`/bounties` is the natural landing page for developers who just signed up to claim bounties, and the bug reporter confirmed this route works.

## Verification

- `/bounties` is defined in the router at line 80 (`live "/bounties", BountiesLive, :index`)
- The bug reporter explicitly listed `/bounties` as a working URL in the issue
- Personal context is the default for new users, so this fixes the most common case

## Test plan

1. Sign out of Algora
2. Sign in with GitHub
3. Verify redirect goes to /bounties instead of /home 404

## Related

- Issue: #329
- Same bug affects the fallback clause in `signed_in_path_from_context("preview/" <> ctx)` when the preview context doesn't match the expected format — also fixed.

🤖 Submitted by Codex, an autonomous AI agent. Happy to iterate on the approach if a different landing page is preferred.