### PR TITLE
add aria-labels to icon buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,0 @@
-## 2026-06-26 - Adding ARIA labels to icon buttons
-**Learning:** Icon buttons used throughout the application without accompanying text needed explicit ARIA labels to ensure screen reader accessibility. I noticed this pattern was present across various chat and contract components.
-**Action:** Ensure all button components with size icon include an aria-label attribute if they only contain an icon.

--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2026-06-26 - Adding ARIA labels to icon buttons
+**Learning:** Icon buttons used throughout the application without accompanying text needed explicit ARIA labels to ensure screen reader accessibility. I noticed this pattern was present across various chat and contract components.
+**Action:** Ensure all button components with size icon include an aria-label attribute if they only contain an icon.

--- a/lib/algora_web/live/bounty_live.ex
+++ b/lib/algora_web/live/bounty_live.ex
@@ -436,6 +436,7 @@ defmodule AlgoraWeb.BountyLive do
                             size="icon-sm"
                             phx-click="exclusive"
                             class="group h-6 w-6"
+                            aria-label="Edit"
                           >
                             <.icon
                               name="tabler-pencil"
@@ -584,12 +585,13 @@ defmodule AlgoraWeb.BountyLive do
                   size="icon-sm"
                   phx-hook="EmojiPicker"
                   id="emoji-trigger"
+                  aria-label="Add emoji"
                 >
                   <.icon name="tabler-mood-smile" class="h-4 w-4" />
                 </.button>
               </div>
             </div>
-            <.button type="submit" size="icon">
+            <.button type="submit" size="icon" aria-label="Send message">
               <.icon name="tabler-send" class="h-4 w-4" />
             </.button>
           </form>

--- a/lib/algora_web/live/contract/view_live.ex
+++ b/lib/algora_web/live/contract/view_live.ex
@@ -181,7 +181,7 @@ defmodule AlgoraWeb.Contract.ViewLive do
 
                                 <.dropdown_menu>
                                   <.dropdown_menu_trigger>
-                                    <.button variant="ghost" size="icon">
+                                    <.button variant="ghost" size="icon" aria-label="Open menu">
                                       <.icon name="tabler-dots-vertical" class="h-4 w-4" />
                                     </.button>
                                   </.dropdown_menu_trigger>
@@ -428,12 +428,13 @@ defmodule AlgoraWeb.Contract.ViewLive do
                   size="icon-sm"
                   phx-hook="EmojiPicker"
                   id="emoji-trigger"
+                  aria-label="Add emoji"
                 >
                   <.icon name="tabler-mood-smile" class="h-4 w-4" />
                 </.button>
               </div>
             </div>
-            <.button type="submit" size="icon">
+            <.button type="submit" size="icon" aria-label="Send message">
               <.icon name="tabler-send" class="h-4 w-4" />
             </.button>
           </form>

--- a/lib/algora_web/live/contract_live.ex
+++ b/lib/algora_web/live/contract_live.ex
@@ -738,12 +738,13 @@ defmodule AlgoraWeb.ContractLive do
                   size="icon-sm"
                   phx-hook="EmojiPicker"
                   id="emoji-trigger"
+                  aria-label="Add emoji"
                 >
                   <.icon name="tabler-mood-smile" class="h-4 w-4" />
                 </.button>
               </div>
             </div>
-            <.button type="submit" size="icon">
+            <.button type="submit" size="icon" aria-label="Send message">
               <.icon name="tabler-send" class="h-4 w-4" />
             </.button>
           </form>

--- a/lib/algora_web/live/org/dashboard_live.ex
+++ b/lib/algora_web/live/org/dashboard_live.ex
@@ -1378,7 +1378,7 @@ defmodule AlgoraWeb.Org.DashboardLive do
             </.button>
             <%!-- <.dropdown_menu>
               <.dropdown_menu_trigger>
-                <.button variant="ghost" size="icon">
+                <.button variant="ghost" size="icon" aria-label="Open menu">
                   <.icon name="tabler-dots" class="h-4 w-4" />
                 </.button>
               </.dropdown_menu_trigger>
@@ -1572,7 +1572,7 @@ defmodule AlgoraWeb.Org.DashboardLive do
                 <h2 class="text-lg font-semibold">Algora Founders</h2>
               </div>
             </div>
-            <.button variant="ghost" size="icon" phx-click="close_chat">
+            <.button variant="ghost" size="icon" phx-click="close_chat" aria-label="Close chat">
               <.icon name="tabler-x" class="h-4 w-4" />
             </.button>
           </div>
@@ -1644,12 +1644,13 @@ defmodule AlgoraWeb.Org.DashboardLive do
                     size="icon-sm"
                     phx-hook="EmojiPicker"
                     id="emoji-trigger"
+                    aria-label="Add emoji"
                   >
                     <.icon name="tabler-mood-smile" class="h-4 w-4" />
                   </.button>
                 </div>
               </div>
-              <.button type="submit" size="icon">
+              <.button type="submit" size="icon" aria-label="Send message">
                 <.icon name="tabler-send" class="h-4 w-4" />
               </.button>
             </form>


### PR DESCRIPTION
💡 What: Added ARIA labels to icon-only buttons across multiple live components (`bounty_live.ex`, `contract/view_live.ex`, `contract_live.ex`, `org/dashboard_live.ex`).
🎯 Why: To ensure screen reader accessibility. Buttons that contain only an icon and no text need an explicit `aria-label` for screen reader users to understand their purpose.
♿ Accessibility: Improved screen reader accessibility for various actions like sending messages, editing, and opening menus.

---
*PR created automatically by Jules for task [14605475153828946619](https://jules.google.com/task/14605475153828946619) started by @zcesur*